### PR TITLE
src: add bison-like exception to the source files

### DIFF
--- a/src/common_c.py
+++ b/src/common_c.py
@@ -4,6 +4,7 @@
 #
 # Copyright (C) Huawei Technologies., Ltd. 2018-2020.
 # Copyright (C) 2017, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+#
 # libocispec is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3 of the License, or
@@ -16,7 +17,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
-#!/usr/bin/python -Es
+
+# As a special exception, you may create a larger work that contains
+# part or all of the libocispec parser skeleton and distribute that work
+# under terms of your choice, so long as that work isn't itself a
+# parser generator using the skeleton or a modified version thereof
+# as a parser skeleton.  Alternatively, if you modify or redistribute
+# the parser skeleton itself, you may (at your option) remove this
+# special exception, which will cause the skeleton and the resulting
+# libocispec output files to be licensed under the GNU General Public
+# License without this special exception.
+
 import os
 import fcntl
 

--- a/src/common_h.py
+++ b/src/common_h.py
@@ -4,6 +4,7 @@
 #
 # Copyright (C) Huawei Technologies., Ltd. 2018-2020.
 # Copyright (C) 2017, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+#
 # libocispec is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3 of the License, or
@@ -16,7 +17,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
-#!/usr/bin/python -Es
+
+# As a special exception, you may create a larger work that contains
+# part or all of the libocispec parser skeleton and distribute that work
+# under terms of your choice, so long as that work isn't itself a
+# parser generator using the skeleton or a modified version thereof
+# as a parser skeleton.  Alternatively, if you modify or redistribute
+# the parser skeleton itself, you may (at your option) remove this
+# special exception, which will cause the skeleton and the resulting
+# libocispec output files to be licensed under the GNU General Public
+# License without this special exception.
 
 import os
 import fcntl

--- a/src/generate.py
+++ b/src/generate.py
@@ -15,6 +15,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
+#
+# As a special exception, you may create a larger work that contains
+# part or all of the libocispec parser skeleton and distribute that work
+# under terms of your choice, so long as that work isn't itself a
+# parser generator using the skeleton or a modified version thereof
+# as a parser skeleton.  Alternatively, if you modify or redistribute
+# the parser skeleton itself, you may (at your option) remove this
+# special exception, which will cause the skeleton and the resulting
+# libocispec output files to be licensed under the GNU General Public
+# License without this special exception.
 
 import traceback
 import os

--- a/src/headers.py
+++ b/src/headers.py
@@ -16,7 +16,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
-#!/usr/bin/python -Es
+#
+# As a special exception, you may create a larger work that contains
+# part or all of the libocispec parser skeleton and distribute that work
+# under terms of your choice, so long as that work isn't itself a
+# parser generator using the skeleton or a modified version thereof
+# as a parser skeleton.  Alternatively, if you modify or redistribute
+# the parser skeleton itself, you may (at your option) remove this
+# special exception, which will cause the skeleton and the resulting
+# libocispec output files to be licensed under the GNU General Public
+# License without this special exception.
 import helpers
 
 def append_header_arr(obj, header, prefix):

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -15,7 +15,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
-#!/usr/bin/python -Es
+#
+# As a special exception, you may create a larger work that contains
+# part or all of the libocispec parser skeleton and distribute that work
+# under terms of your choice, so long as that work isn't itself a
+# parser generator using the skeleton or a modified version thereof
+# as a parser skeleton.  Alternatively, if you modify or redistribute
+# the parser skeleton itself, you may (at your option) remove this
+# special exception, which will cause the skeleton and the resulting
+# libocispec output files to be licensed under the GNU General Public
+# License without this special exception.
 import os
 import sys
 

--- a/src/sources.py
+++ b/src/sources.py
@@ -4,6 +4,7 @@
 #
 # Copyright (C) Huawei Technologies., Ltd. 2018-2020.
 # Copyright (C) 2017, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+#
 # libocispec is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3 of the License, or
@@ -16,7 +17,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
-#!/usr/bin/python -Es
+#
+# As a special exception, you may create a larger work that contains
+# part or all of the libocispec parser skeleton and distribute that work
+# under terms of your choice, so long as that work isn't itself a
+# parser generator using the skeleton or a modified version thereof
+# as a parser skeleton.  Alternatively, if you modify or redistribute
+# the parser skeleton itself, you may (at your option) remove this
+# special exception, which will cause the skeleton and the resulting
+# libocispec output files to be licensed under the GNU General Public
+# License without this special exception.
+
 import helpers
 
 


### PR DESCRIPTION
add the possibility to use the generated code with any license, as
long as the project itself is not a parser/generator.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>