### PR TITLE
De-duplicate json_common in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ GITIGNOREFILES = build-aux/ gtk-doc.make config.h.in aclocal.m4
 noinst_LTLIBRARIES = libocispec.la
 noinst_LIBRARIES = libocispec.a
 
-SOURCE_FILES = src/json_common.c \
+SOURCE_FILES = \
 	src/image_spec_schema_config_schema.c \
 	src/image_spec_schema_content_descriptor.c \
 	src/image_spec_schema_defs.c \


### PR DESCRIPTION
The source file src/json_common.c is listed twice in Makefile.am,
leading libtool to produce an archive with duplicated symbols. This
change removes the duplicate source.

This was introduced in commit 2e318803a2c49521ea448e3ae010b1564a7e95ed

Signed-off-by: Bruce Guenter <bruce@untroubled.org>