### PR TITLE
support keep all keys and values even unkonwn

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,6 +94,9 @@ tests_test_7_LDADD = $(TESTS_LDADD)
 tests_test_8_SOURCES = tests/test-8.c
 tests_test_8_LDADD = $(TESTS_LDADD)
 
+tests_test_9_SOURCES = tests/test-9.c
+tests_test_9_LDADD = $(TESTS_LDADD)
+
 src_validate_SOURCES = src/validate.c
 src_validate_LDADD = $(TESTS_LDADD)
 
@@ -104,7 +107,8 @@ TESTS = tests/test-1 \
 	tests/test-5 \
 	tests/test-6 \
 	tests/test-7 \
-	tests/test-8
+	tests/test-8 \
+	tests/test-9
 
 noinst_PROGRAMS = src/validate $(TESTS)
 
@@ -124,6 +128,7 @@ EXTRA_DIST = autogen.sh \
 	tests/data/image_config.json \
 	tests/data/config.nocwd.json \
 	tests/data/image_manifest_item.json \
+	tests/data/residual_image_layout_config.json \
 	tests/test-spec \
 	src/generate.py \
 	src/common_c.py \

--- a/src/common_h.py
+++ b/src/common_h.py
@@ -65,8 +65,10 @@ extern "C" {
 # define OPT_GEN_KEY_VALUE 0x02
 // options to generate simplify(no indent) json string
 # define OPT_GEN_SIMPLIFY 0x04
+// options to keep all keys and values, even do not known
+# define OPT_PARSE_FULLKEY 0x08
 // options not to validate utf8 data
-# define OPT_GEN_NO_VALIDATE_UTF8 0x08
+# define OPT_GEN_NO_VALIDATE_UTF8 0x10
 
 # define GEN_SET_ERROR_AND_RETURN(stat, err) { \\
     if (*(err) == NULL) {\\
@@ -84,6 +86,8 @@ struct parser_context
   unsigned int options;
   FILE *errfile;
 };
+
+yajl_gen_status gen_yajl_object_residual (yajl_val obj, yajl_gen g, parser_error *err);
 
 yajl_gen_status map_uint (void *ctx, long long unsigned int num);
 

--- a/src/generate.py
+++ b/src/generate.py
@@ -736,6 +736,7 @@ def handle_single_file(args, srcpath, gen_ref, schemapath):
                         schema_info = schema_from_file(os.path.join(dirpath, target_file), \
                                                        srcpath.name)
                         reflection(schema_info, gen_ref)
+                        print("\033[1;34mReflection:\033[0m\t%-60s \033[1;32mSuccess\033[0m" % (target_file))
         else:
             # only parse files in current direcotory
             for target_file in os.listdir(schemapath.name):
@@ -743,10 +744,12 @@ def handle_single_file(args, srcpath, gen_ref, schemapath):
                 if fullpath.endswith(JSON_SUFFIX) and os.path.isfile(fullpath):
                     schema_info = schema_from_file(fullpath, srcpath.name)
                     reflection(schema_info, gen_ref)
+                    print("\033[1;34mReflection:\033[0m\t%-60s \033[1;32mSuccess\033[0m" % (fullpath))
     else:
         if schemapath.name.endswith(JSON_SUFFIX):
             schema_info = schema_from_file(schemapath.name, srcpath.name)
             reflection(schema_info, gen_ref)
+            print("\033[1;34mReflection:\033[0m\t%-60s \033[1;32mSuccess\033[0m" % (schemapath.name))
         else:
             print('File %s is not ends with .json' % schemapath.name)
 

--- a/src/headers.py
+++ b/src/headers.py
@@ -155,6 +155,8 @@ def append_type_c_header(obj, header, prefix):
                 append_header_child_others(i, header, prefix)
             if helpers.judge_data_type(i.typ) or i.typ == 'boolean':
                 header.write("    unsigned int %s_present : 1;\n" % (i.fixname))
+        if obj.children is not None:
+            header.write("    yajl_val _residual;\n")
     typename = helpers.get_prefixed_name(obj.name, prefix)
     header.write("}\n%s;\n\n" % typename)
     header.write("void free_%s (%s *ptr);\n\n" % (typename, typename))

--- a/tests/data/residual_image_layout_config.json
+++ b/tests/data/residual_image_layout_config.json
@@ -1,0 +1,16 @@
+{
+    "imageLayoutVersion": "1.0.0",
+    "residual_int": 1,
+    "residual_float": 1.1,
+    "residual_string": "residual",
+    "residual_true": true,
+    "residual_false": false,
+    "residual_array": [
+        1, 2, 3, 4, 5, 6
+    ],
+    "residual_obj": {
+        "key1": "value1",
+        "key2": "value2",
+        "key3": "value3"
+    }
+}

--- a/tests/test-9.c
+++ b/tests/test-9.c
@@ -1,0 +1,84 @@
+/* Copyright (C) 2017 Wang Long <w@laoqinren.net>
+
+libocispec is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+libocispec is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "config.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "image_spec_schema_image_layout_schema.h"
+
+int
+main ()
+{
+  parser_error err;
+  struct parser_context ctx;
+  ctx.options = OPT_PARSE_FULLKEY;
+
+  image_spec_schema_image_layout_schema *image_layout = image_spec_schema_image_layout_schema_parse_file ("tests/data/residual_image_layout_config.json", &ctx, &err);
+  image_spec_schema_image_layout_schema *image_layout_gen = NULL;
+  char *json_buf = NULL;
+
+  if (image_layout == NULL) {
+    printf ("error %s\n", err);
+    exit (1);
+  }
+  json_buf = image_spec_schema_image_layout_schema_generate_json(image_layout, &ctx, &err);
+  if (json_buf == NULL) {
+    printf("gen error %s\n", err);
+    exit (1);
+  }
+  image_layout_gen = image_spec_schema_image_layout_schema_parse_data(json_buf, 0, &err);
+  if (image_layout_gen == NULL) {
+    printf("parse error %s\n", err);
+    exit(1);
+  }
+
+  if (strcmp (image_layout->image_layout_version, "1.0.0") && strcmp (image_layout->image_layout_version, image_layout_gen->image_layout_version))
+    exit (5);
+
+  printf("%s\n", json_buf);
+
+  // origin json str should same with generate new json str,
+  if (strstr(json_buf, "residual_int") == NULL)
+    exit (51);
+  if (strstr(json_buf, "residual_float") == NULL)
+    exit (52);
+  if (strstr(json_buf, "residual_string") == NULL)
+    exit (53);
+  if (strstr(json_buf, "residual_true") == NULL)
+    exit (54);
+  if (strstr(json_buf, "residual_false") == NULL)
+    exit (55);
+  if (strstr(json_buf, "residual_array") == NULL)
+    exit (56);
+  if (strstr(json_buf, "residual_obj") == NULL)
+    exit (57);
+  if (strstr(json_buf, "key1") == NULL ||
+          strstr(json_buf, "key2") == NULL ||
+          strstr(json_buf, "key3") == NULL)
+    exit (58);
+  if (strstr(json_buf, "value1") == NULL ||
+          strstr(json_buf, "value2") == NULL ||
+          strstr(json_buf, "value3") == NULL)
+    exit (59);
+
+  free(json_buf);
+  free_image_spec_schema_image_layout_schema (image_layout);
+  free_image_spec_schema_image_layout_schema (image_layout_gen);
+  exit (0);
+}


### PR DESCRIPTION
some scenes need keep all json data, and pass to other handler. Such as CNI, spec of CNI only support basic member, but all plugins of [CNI extend member of network conf.](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration)

So, we need keep all json keys and values.