### PR TITLE
fix memory leak

### DIFF
--- a/src/common_c.py
+++ b/src/common_c.py
@@ -116,14 +116,18 @@ static yajl_gen_status gen_yajl_val (yajl_val obj, yajl_gen g, parser_error *err
                 return __stat;
             }
             __stat = yajl_gen_string (g, (const unsigned char *) __tstr, strlen (__tstr));
-            GEN_SET_ERROR_AND_RETURN (__stat, err);
+            if (yajl_gen_status_ok != __stat)
+                GEN_SET_ERROR_AND_RETURN (__stat, err);
+            return yajl_gen_status_ok;
         case yajl_t_number:
             __tstr = YAJL_GET_NUMBER (obj);
             if (__tstr == NULL) {
                 return __stat;
             }
             __stat = yajl_gen_number (g, __tstr, strlen (__tstr));
-            GEN_SET_ERROR_AND_RETURN (__stat, err);
+            if (yajl_gen_status_ok != __stat)
+                GEN_SET_ERROR_AND_RETURN (__stat, err);
+            return yajl_gen_status_ok;
         case yajl_t_object:
             return gen_yajl_val_obj (obj, g, err);
         case yajl_t_array:

--- a/src/sources.py
+++ b/src/sources.py
@@ -1165,6 +1165,7 @@ yajl_gen_status gen_%s (yajl_gen g, const %s_element **ptr, size_t len, const st
         return NULL;
       }
     ptr = make_%s (tree, ctx, err%s);
+    yajl_tree_free (tree);
     return ptr;
 }
 """ % (prefix, '' if typ == 'object' else ', len'))

--- a/tests/test-9.c
+++ b/tests/test-9.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Wang Long <w@laoqinren.net>
+/* Copyright (C) 2020 duguhaotian <knowledgehao@163.com>
 
 libocispec is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -40,11 +40,13 @@ main ()
   json_buf = image_spec_schema_image_layout_schema_generate_json(image_layout, &ctx, &err);
   if (json_buf == NULL) {
     printf("gen error %s\n", err);
+    free(err);
     exit (1);
   }
   image_layout_gen = image_spec_schema_image_layout_schema_parse_data(json_buf, 0, &err);
   if (image_layout_gen == NULL) {
     printf("parse error %s\n", err);
+    free(err);
     exit(1);
   }
 


### PR DESCRIPTION
before

```
$ valgrind --leak-check=full  ./tests/test-9
==30662== Memcheck, a memory error detector
==30662== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==30662== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==30662== Command: ./tests/test-9
==30662== 
gen error src/json_common.c: gen_yajl_val: 83: error generating json, errcode: 0
{
    "imageLayoutVersion": "1.0.0",
    "residual_int": 1,
    "residual_float": 1.1,
    "residual_string": "residual",
    "residual_true": true,
    "residual_false": false,
    "residual_array": [
        1,
        2,
        3,
        4,
        5,
        6
    ],
    "residual_obj": {
        "key1": "value1",
        "key2": "value2",
        "key3": "value3"
    }
}

==30662== 
==30662== HEAP SUMMARY:
==30662==     in use at exit: 1,437 bytes in 54 blocks
==30662==   total heap usage: 197 allocs, 143 frees, 26,576 bytes allocated
==30662== 
==30662== 71 bytes in 1 blocks are definitely lost in loss record 15 of 21
==30662==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==30662==    by 0x48F6D88: __vasprintf_internal (vasprintf.c:79)
==30662==    by 0x48CD109: asprintf (asprintf.c:31)
==30662==    by 0x10BB9B: gen_yajl_val (json_common.c:83)
==30662==    by 0x10BD3F: gen_yajl_object_residual (json_common.c:113)
==30662==    by 0x10B016: gen_image_spec_schema_image_layout_schema (image_spec_schema_image_layout_schema.c:138)
==30662==    by 0x10B4E5: image_spec_schema_image_layout_schema_generate_json (image_spec_schema_image_layout_schema.c:238)
==30662==    by 0x10A715: main (test-9.c:40)
==30662== 
==30662== 233 (40 direct, 193 indirect) bytes in 1 blocks are definitely lost in loss record 19 of 21
==30662==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==30662==    by 0x48624BC: ??? (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
==30662==    by 0x48628CD: ??? (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
==30662==    by 0x485F85E: ??? (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
==30662==    by 0x48629EE: yajl_tree_parse (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
==30662==    by 0x10B374: image_spec_schema_image_layout_schema_parse_data (image_spec_schema_image_layout_schema.c:207)
==30662==    by 0x10B1C1: image_spec_schema_image_layout_schema_parse_file (image_spec_schema_image_layout_schema.c:167)
==30662==    by 0x10A6C1: main (test-9.c:32)
==30662== 
==30662== 1,133 (40 direct, 1,093 indirect) bytes in 1 blocks are definitely lost in loss record 21 of 21
==30662==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==30662==    by 0x48624BC: ??? (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
==30662==    by 0x48628CD: ??? (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
==30662==    by 0x485F85E: ??? (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
==30662==    by 0x48629EE: yajl_tree_parse (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
==30662==    by 0x10B374: image_spec_schema_image_layout_schema_parse_data (image_spec_schema_image_layout_schema.c:207)
==30662==    by 0x10A77B: main (test-9.c:47)
==30662== 
==30662== LEAK SUMMARY:
==30662==    definitely lost: 151 bytes in 3 blocks
==30662==    indirectly lost: 1,286 bytes in 51 blocks
==30662==      possibly lost: 0 bytes in 0 blocks
==30662==    still reachable: 0 bytes in 0 blocks
==30662==         suppressed: 0 bytes in 0 blocks
==30662== 
==30662== For lists of detected and suppressed errors, rerun with: -s
==30662== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)

```

after

```
$ valgrind --leak-check=full  ./tests/test-9
==33797== Memcheck, a memory error detector
==33797== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==33797== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==33797== Command: ./tests/test-9
==33797== 
{
    "imageLayoutVersion": "1.0.0",
    "residual_int": 1,
    "residual_float": 1.1,
    "residual_string": "residual",
    "residual_true": true,
    "residual_false": false,
    "residual_array": [
        1,
        2,
        3,
        4,
        5,
        6
    ],
    "residual_obj": {
        "key1": "value1",
        "key2": "value2",
        "key3": "value3"
    }
}

==33797== 
==33797== HEAP SUMMARY:
==33797==     in use at exit: 0 bytes in 0 blocks
==33797==   total heap usage: 195 allocs, 195 frees, 26,405 bytes allocated
==33797== 
==33797== All heap blocks were freed -- no leaks are possible
==33797== 
==33797== For lists of detected and suppressed errors, rerun with: -s
==33797== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```