### PR TITLE
use gcc cleanup attribute to refactor the commom module code and form…

### DIFF
--- a/src/common_h.py
+++ b/src/common_h.py
@@ -70,6 +70,20 @@ extern "C" {
 // options not to validate utf8 data
 # define OPT_GEN_NO_VALIDATE_UTF8 0x10
 
+#define define_cleaner_function(type, cleaner)           \
+        static inline void cleaner##_function(type *ptr) \
+        {                                                \
+                if (*ptr)                                \
+                        cleaner(*ptr);                   \
+        }
+
+#define __auto_cleanup(cleaner) __attribute__((__cleanup__(cleaner##_function)))
+
+static inline void ptr_free_function(void *p) {
+    free(*(void**)p);
+}
+#define __auto_free __auto_cleanup(ptr_free)
+
 # define GEN_SET_ERROR_AND_RETURN(stat, err) { \\
     if (*(err) == NULL) {\\
         if (asprintf (err, "%s: %s: %d: error generating json, errcode: %u", __FILE__, __func__, __LINE__, stat) < 0) { \\


### PR DESCRIPTION
…at it
```bash
➜  libocispec git:(master) ✗ make check
make: Circular /root/workspace/third-party/libocispec/tests/data <- /root/workspace/third-party/libocispec/tests/data dependency dropped.
  GEN      public-submodule-commit
make  check-am
make[1]: Entering directory '/root/workspace/third-party/libocispec'
make  check-TESTS
make[2]: Entering directory '/root/workspace/third-party/libocispec'
make[3]: Entering directory '/root/workspace/third-party/libocispec'
PASS: tests/test-1
PASS: tests/test-2
PASS: tests/test-3
PASS: tests/test-4
PASS: tests/test-5
PASS: tests/test-6
PASS: tests/test-7
PASS: tests/test-8
PASS: tests/test-9
============================================================================
Testsuite summary for libocispec 0.2
============================================================================
# TOTAL: 9
# PASS:  9
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[3]: Leaving directory '/root/workspace/third-party/libocispec'
make[2]: Leaving directory '/root/workspace/third-party/libocispec'
make[1]: Leaving directory '/root/workspace/third-party/libocispec'
```
Signed-off-by: wujing <wujing50@huawei.com>