### PR TITLE
fix memory leak of double array

### DIFF
--- a/tests/test-10.c
+++ b/tests/test-10.c
@@ -30,8 +30,9 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 do_test_object_double_array()
 {
-  parser_error err;
+  parser_error err = NULL;
   struct parser_context ctx = { 0 };
+  int ret = 0;
 
   basic_test_double_array *test_data = basic_test_double_array_parse_file(
           "tests/data/doublearray.json", &ctx, &err);
@@ -40,14 +41,15 @@ do_test_object_double_array()
 
   if (test_data == NULL) {
     printf ("error %s\n", err);
+    free(err);
     return 1;
   }
 
   // check double array of string
   if (test_data->strarrays_len != 3) {
       printf("invalid strarrays len\n");
-      free(err);
-      return 1;
+      ret = 1;
+      goto out;
   }
   char *expect_strs[3][4] = {
       {"stra", "strb", "strc", NULL},
@@ -59,23 +61,27 @@ do_test_object_double_array()
   for (i = 0; i < 3; i++) {
       if (test_data->strarrays[i] == NULL || test_data->strarrays_item_lens == NULL) {
         printf("item %zu is null\n", i);
-        return 1;
+        ret = 1;
+        goto out;
       }
       if (test_data->strarrays_item_lens[i] != str_lens[i]) {
         printf("double array str item %zu is expect len: %zu, get: %zu\n", i, str_lens[i], test_data->strarrays_item_lens[i]);
-        return 1;
+        ret = 1;
+        goto out;
       }
       for (j = 0; j < 4 && expect_strs[i][j] != NULL; j++) {
           if (test_data->strarrays[i][j] == NULL || strcmp(test_data->strarrays[i][j], expect_strs[i][j]) != 0) {
               printf("item %zu: expect: %s, get: %s\n", i, expect_strs[i][j], test_data->strarrays[i][j]);
-              return 1;
+              ret = 1;
+              goto out;
           }
       }
   }
   // check double array of int32
   if (test_data->intarrays_len != 3) {
       printf("invalid intarrays len\n");
-      return 1;
+      ret = 1;
+      goto out;
   }
   int32_t expect_ints[3][4] = {
       {1},
@@ -86,16 +92,19 @@ do_test_object_double_array()
   for (i = 0; i < 3; i++) {
       if (test_data->intarrays[i] == NULL || test_data->intarrays_item_lens == NULL) {
         printf("item %zu is null\n", i);
-        return 1;
+        ret = 1;
+        goto out;
       }
       if (test_data->intarrays_item_lens[i] != int_lens[i]) {
         printf("double array int item %zu is expect len: %zu, get: %zu\n", i, int_lens[i], test_data->intarrays_item_lens[i]);
-        return 1;
+        ret = 1;
+        goto out;
       }
       for (j = 0; j < 4 && expect_ints[i][j] != 0; j++) {
           if (test_data->intarrays[i][j] != expect_ints[i][j]) {
               printf("item %zu: expect: %d, get: %d\n", i, expect_ints[i][j], test_data->intarrays[i][j]);
-              return 1;
+              ret = 1;
+              goto out;
           }
       }
   }
@@ -103,7 +112,8 @@ do_test_object_double_array()
   // check bool array of int32
   if (test_data->boolarrays_len != 4) {
       printf("invalid bool arrays len\n");
-      return 1;
+      ret = 1;
+      goto out;
   }
   int32_t expect_bools[4][2] = {
       {true, false},
@@ -116,16 +126,19 @@ do_test_object_double_array()
   for (i = 0; i < 4; i++) {
       if (test_data->boolarrays[i] == NULL || test_data->boolarrays_item_lens == NULL) {
         printf("item %zu is null\n", i);
-        return 1;
+        ret = 1;
+        goto out;
       }
       if (test_data->boolarrays_item_lens[i] != bool_lens[i]) {
         printf("double array bool item %zu is expect len: %zu, get: %zu\n", i, bool_lens[i], test_data->boolarrays_item_lens[i]);
-        return 1;
+        ret = 1;
+        goto out;
       }
       for (j = 0; j < bool_lens[i]; j++) {
           if (test_data->boolarrays[i][j] != expect_bools[i][j]) {
               printf("item %zu: expect: %d, get: %d\n", i, expect_bools[i][j], test_data->boolarrays[i][j]);
-              return 1;
+              ret = 1;
+              goto out;
           }
       }
   }
@@ -134,7 +147,8 @@ do_test_object_double_array()
   // check object array of int32
   if (test_data->objectarrays_len != 2) {
       printf("invalid object arrays len\n");
-      return 1;
+      ret = 1;
+      goto out;
   }
   bool obj_firsts[2][3] = {
       {true, false, true},
@@ -147,19 +161,22 @@ do_test_object_double_array()
   for (i = 0; i < 2; i++) {
       if (test_data->objectarrays[i] == NULL || test_data->objectarrays_item_lens == NULL) {
         printf("object array item %zu: is null\n", i);
-        return 1;
+        ret = 1;
+        goto out;
       }
       for (j = 0; j < 3; j++) {
           if (obj_firsts[i][j] != test_data->objectarrays[i][j]->first) {
               printf("item %zu -> %zu: expect: %d, get: %d\n", 
                       i, j, obj_firsts[i][j], test_data->objectarrays[i][j]->first);
-              return 1;
+              ret = 1;
+              goto out;
           }
           if (test_data->objectarrays[i][j]->second == NULL || 
                   strcmp(obj_seconds[i][j], test_data->objectarrays[i][j]->second) != 0) {
               printf("item %zu -> %zu: expect: %s, get: %s\n", 
                       i, j, obj_seconds[i][j], test_data->objectarrays[i][j]->second);
-              return 1;
+              ret = 1;
+              goto out;
           }
       }
   }
@@ -167,7 +184,8 @@ do_test_object_double_array()
   // check ref object array of int32
   if (test_data->refobjarrays_len != 2) {
       printf("invalid ref object arrays len\n");
-      return 1;
+      ret = 1;
+      goto out;
   }
   char *refobj_item1[2][3] = {
       {"first1", "first2", "first3"},
@@ -184,24 +202,28 @@ do_test_object_double_array()
   for (i = 0; i < 2; i++) {
       if (test_data->refobjarrays[i] == NULL || test_data->refobjarrays_item_lens == NULL) {
         printf("object array item %zu: is null\n", i);
-        return 1;
+        ret = 1;
+        goto out;
       }
       for (j = 0; j < 3; j++) {
           if (refobj_item3[i][j] != test_data->refobjarrays[i][j]->item3) {
               printf("item %zu -> %zu: expect: %d, get: %d\n", 
                       i, j, refobj_item3[i][j], test_data->refobjarrays[i][j]->item3);
-              return 1;
+              ret = 1;
+              goto out;
           }
           if (refobj_item2[i][j] != test_data->refobjarrays[i][j]->item2) {
               printf("item %zu -> %zu: expect: %d, get: %d\n", 
                       i, j, refobj_item2[i][j], test_data->refobjarrays[i][j]->item2);
-              return 1;
+              ret = 1;
+              goto out;
           }
           if (test_data->refobjarrays[i][j]->item1 == NULL || 
                   strcmp(refobj_item1[i][j], test_data->refobjarrays[i][j]->item1) != 0) {
               printf("item %zu -> %zu: expect: %s, get: %s\n", 
                       i, j, refobj_item1[i][j], test_data->refobjarrays[i][j]->item1);
-              return 1;
+              ret = 1;
+              goto out;
           }
       }
   }
@@ -219,30 +241,44 @@ do_test_object_double_array()
   json_buf = basic_test_double_array_generate_json(test_data, &ctx, &err);
   if (json_buf == NULL) {
     printf("gen error %s\n", err);
-    free(err);
-    return 1;
+    ret = 1;
+    goto out;
   }
 
   printf("%s\n", json_buf);
 
   // origin json str should same with generate new json str,
   if (strstr(json_buf, "stringtestflag") == NULL)
-    return 51;
+  {
+      ret = 51;
+      goto out;
+  }
   if (strstr(json_buf, "objectteststr") == NULL)
-    return 52;
+  {
+      ret = 52;
+      goto out;
+  }
   if (strstr(json_buf, "objectrefstr") == NULL)
-    return 53;
+  {
+      ret = 53;
+      goto out;
+  }
   if (strstr(json_buf, "8888") == NULL)
-    return 54;
+  {
+      ret = 54;
+      goto out;
+  }
 
+out:
+  free(err);
   free(json_buf);
   free_basic_test_double_array(test_data);
-  return 0;
+  return ret;
 }
 
 int do_test_top_array_of_int()
 {
-  parser_error err;
+  parser_error err = NULL;
   struct parser_context ctx = { 0 };
   int ret = 0;
 
@@ -298,7 +334,7 @@ out:
 
 int do_test_top_array_of_string()
 {
-  parser_error err;
+  parser_error err = NULL;
   struct parser_context ctx = { 0 };
   int ret = 0;
 
@@ -355,7 +391,7 @@ out:
 
 int do_test_top_double_array_of_string()
 {
-  parser_error err;
+  parser_error err = NULL;
   struct parser_context ctx = { 0 };
   int ret = 0;
 
@@ -415,15 +451,15 @@ int do_test_top_double_array_of_string()
   }
 
 out:
-  free(err);
   free_basic_test_top_double_array_string_container(test_data);
+  free(err);
   free(json_buf);
   return ret;
 }
 
 int do_test_top_double_array_of_int()
 {
-  parser_error err;
+  parser_error err = NULL;
   struct parser_context ctx = { 0 };
   int ret = 0;
 
@@ -490,7 +526,7 @@ out:
 
 int do_test_top_double_array_of_obj()
 {
-  parser_error err;
+  parser_error err = NULL;
   struct parser_context ctx = { 0 };
   int ret = 0;
 


### PR DESCRIPTION
use valgrind check memory leak of test-10

```
$ valgrind --fair-sched=yes --tool=memcheck --leak-check=yes -v --track-origins=yes ./tests/test-10 
==76411== Memcheck, a memory error detector
==76411== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==76411== Using Valgrind-3.15.0-608cb11914-20190413 and LibVEX; rerun with -h for copyright info
==76411== Command: ./tests/test-10
==76411== 
--76411-- Valgrind options:
--76411--    --fair-sched=yes
--76411--    --tool=memcheck
--76411--    --leak-check=yes
--76411--    -v
--76411--    --track-origins=yes
--76411-- Contents of /proc/version:
--76411--   Linux version 5.4.0-52-generic (buildd@lgw01-amd64-060) (gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)) #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020
--76411-- 
--76411-- Arch and hwcaps: AMD64, LittleEndian, amd64-cx16-lzcnt-rdtscp-sse3-ssse3-avx-avx2-bmi-f16c-rdrand
--76411-- Page sizes: currently 4096, max supported 4096
--76411-- Valgrind library directory: /usr/lib/x86_64-linux-gnu/valgrind
--76411-- Reading syms from /home/haozi/work/github/libocispec/tests/test-10
--76411-- Reading syms from /usr/lib/x86_64-linux-gnu/ld-2.31.so
--76411--   Considering /usr/lib/x86_64-linux-gnu/ld-2.31.so ..
--76411--   .. CRC mismatch (computed 6cded93a wanted 1af57820)
--76411--   Considering /lib/x86_64-linux-gnu/ld-2.31.so ..
--76411--   .. CRC mismatch (computed 6cded93a wanted 1af57820)
--76411--   Considering /usr/lib/debug/lib/x86_64-linux-gnu/ld-2.31.so ..
--76411--   .. CRC is valid
--76411-- Reading syms from /usr/lib/x86_64-linux-gnu/valgrind/memcheck-amd64-linux
--76411--    object doesn't have a symbol table
--76411--    object doesn't have a dynamic symbol table
--76411-- Scheduler: using ticket lock scheduler lock implementation.
--76411-- Reading suppressions file: /usr/lib/x86_64-linux-gnu/valgrind/default.supp
==76411== embedded gdbserver: reading from /tmp/vgdb-pipe-from-vgdb-to-76411-by-haozi-on-???
==76411== embedded gdbserver: writing to   /tmp/vgdb-pipe-to-vgdb-from-76411-by-haozi-on-???
==76411== embedded gdbserver: shared mem   /tmp/vgdb-pipe-shared-mem-vgdb-76411-by-haozi-on-???
==76411== 
==76411== TO CONTROL THIS PROCESS USING vgdb (which you probably
==76411== don't want to do, unless you know exactly what you're doing,
==76411== or are doing some strange experiment):
==76411==   /usr/lib/x86_64-linux-gnu/valgrind/../../bin/vgdb --pid=76411 ...command...
==76411== 
==76411== TO DEBUG THIS PROCESS USING GDB: start GDB like this
==76411==   /path/to/gdb ./tests/test-10
==76411== and then give GDB the following command
==76411==   target remote | /usr/lib/x86_64-linux-gnu/valgrind/../../bin/vgdb --pid=76411
==76411== --pid is optional if only one valgrind process is running
==76411== 
--76411-- REDIR: 0x4022d80 (ld-linux-x86-64.so.2:strlen) redirected to 0x580c9ce2 (???)
--76411-- REDIR: 0x4022b50 (ld-linux-x86-64.so.2:index) redirected to 0x580c9cfc (???)
--76411-- Reading syms from /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_core-amd64-linux.so
--76411--    object doesn't have a symbol table
--76411-- Reading syms from /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so
--76411--    object doesn't have a symbol table
==76411== WARNING: new redirection conflicts with existing -- ignoring it
--76411--     old: 0x04022d80 (strlen              ) R-> (0000.0) 0x580c9ce2 ???
--76411--     new: 0x04022d80 (strlen              ) R-> (2007.0) 0x0483f060 strlen
--76411-- REDIR: 0x401f560 (ld-linux-x86-64.so.2:strcmp) redirected to 0x483ffd0 (strcmp)
--76411-- REDIR: 0x40232e0 (ld-linux-x86-64.so.2:mempcpy) redirected to 0x4843a20 (mempcpy)
--76411-- Reading syms from /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0
--76411--    object doesn't have a symbol table
--76411-- Reading syms from /usr/lib/x86_64-linux-gnu/libc-2.31.so
--76411--   Considering /usr/lib/x86_64-linux-gnu/libc-2.31.so ..
--76411--   .. CRC mismatch (computed cd1655d1 wanted 09373696)
--76411--   Considering /lib/x86_64-linux-gnu/libc-2.31.so ..
--76411--   .. CRC mismatch (computed cd1655d1 wanted 09373696)
--76411--   Considering /usr/lib/debug/lib/x86_64-linux-gnu/libc-2.31.so ..
--76411--   .. CRC is valid
--76411-- REDIR: 0x490e600 (libc.so.6:memmove) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d900 (libc.so.6:strncpy) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e930 (libc.so.6:strcasecmp) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d220 (libc.so.6:strcat) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d960 (libc.so.6:rindex) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490fdd0 (libc.so.6:rawmemchr) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x492ae60 (libc.so.6:wmemchr) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x492a9a0 (libc.so.6:wcscmp) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e760 (libc.so.6:mempcpy) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e590 (libc.so.6:bcmp) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d890 (libc.so.6:strncmp) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d2d0 (libc.so.6:strcmp) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e6c0 (libc.so.6:memset) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x492a960 (libc.so.6:wcschr) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d7f0 (libc.so.6:strnlen) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d3b0 (libc.so.6:strcspn) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e980 (libc.so.6:strncasecmp) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d350 (libc.so.6:strcpy) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490ead0 (libc.so.6:memcpy@@GLIBC_2.14) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x492c0d0 (libc.so.6:wcsnlen) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x492a9e0 (libc.so.6:wcscpy) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d9a0 (libc.so.6:strpbrk) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d280 (libc.so.6:index) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490d7b0 (libc.so.6:strlen) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x4916d20 (libc.so.6:memrchr) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e9d0 (libc.so.6:strcasecmp_l) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e550 (libc.so.6:memchr) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x492aab0 (libc.so.6:wcslen) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490dc60 (libc.so.6:strspn) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e8d0 (libc.so.6:stpncpy) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e870 (libc.so.6:stpcpy) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490fe10 (libc.so.6:strchrnul) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490ea20 (libc.so.6:strncasecmp_l) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x490e470 (libc.so.6:strstr) redirected to 0x48311d0 (_vgnU_ifunc_wrapper)
--76411-- REDIR: 0x49f6490 (libc.so.6:__strrchr_avx2) redirected to 0x483ea10 (rindex)
--76411-- REDIR: 0x4908260 (libc.so.6:malloc) redirected to 0x483b780 (malloc)
--76411-- REDIR: 0x490e120 (libc.so.6:__GI_strstr) redirected to 0x4843ca0 (__strstr_sse2)
--76411-- REDIR: 0x4909000 (libc.so.6:realloc) redirected to 0x483df30 (realloc)
--76411-- REDIR: 0x4908850 (libc.so.6:free) redirected to 0x483c9d0 (free)
--76411-- REDIR: 0x49f9af0 (libc.so.6:__memset_avx2_unaligned_erms) redirected to 0x48428e0 (memset)
--76411-- REDIR: 0x49f6660 (libc.so.6:__strlen_avx2) redirected to 0x483ef40 (strlen)
--76411-- REDIR: 0x4909c90 (libc.so.6:calloc) redirected to 0x483dce0 (calloc)
--76411-- REDIR: 0x49f9670 (libc.so.6:__memcpy_avx_unaligned_erms) redirected to 0x48429f0 (memmove)
--76411-- REDIR: 0x49f1b60 (libc.so.6:__strcmp_avx2) redirected to 0x483fed0 (strcmp)
double array of object check parse sucess
--76411-- REDIR: 0x49f62a0 (libc.so.6:__strchrnul_avx2) redirected to 0x4843540 (strchrnul)
--76411-- REDIR: 0x49f9650 (libc.so.6:__mempcpy_avx_unaligned_erms) redirected to 0x4843660 (mempcpy)
--76411-- REDIR: 0x4929560 (libc.so.6:__strstr_sse2_unaligned) redirected to 0x4843c20 (strstr)
==76411== 
==76411== HEAP SUMMARY:
==76411==     in use at exit: 0 bytes in 0 blocks
==76411==   total heap usage: 665 allocs, 665 frees, 128,029 bytes allocated
==76411== 
==76411== All heap blocks were freed -- no leaks are possible
==76411== 
==76411== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```