### PR TITLE
build: split automake rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,3 @@ src/runtime_spec_schema_defs_windows.c
 src/runtime_spec_schema_defs_windows.h
 src/runtime_spec_schema_state_schema.c
 src/runtime_spec_schema_state_schema.h
-src/json_common.c
-src/json_common.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
-CLEANFILES = $(man_MANS)
-
 AM_CFLAGS = $(WARN_CFLAGS) -I$(top_srcdir)/src -I$(top_builddir)/src
+
+CLEANFILES = $(man_MANS) src/runtime_spec_stamp src/image_spec_stamp src/image_manifest_stamp src/basic-test_stamp
 
 GITIGNOREFILES = build-aux/ gtk-doc.make config.h.in aclocal.m4
 
@@ -32,28 +32,25 @@ SOURCE_FILES = \
 	src/basic_test_top_array_string.c \
 	src/basic_test_top_double_array_int.c \
 	src/basic_test_top_double_array_obj.c \
-	src/basic_test_top_double_array_string.c \
-	src/json_common.c
+	src/basic_test_top_double_array_string.c
 
 HEADER_FILES = $(SOURCE_FILES:.c=.h)
 
-
 src/runtime_spec_stamp: src/json_common.h src/json_common.c
 	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir} --out=${srcdir}/src ${srcdir}/runtime-spec/schema
+	@touch $@
 
 src/image_spec_stamp: src/json_common.h src/json_common.c
 	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir} --out=${srcdir}/src ${srcdir}/image-spec/schema
+	@touch $@
 
 src/image_manifest_stamp: src/json_common.h src/json_common.c
 	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir}/tests/test-spec --out=${srcdir}/src ${srcdir}/tests/test-spec/imageManifestItems
+	@touch $@
 
-src/basic-test-stamp: src/json_common.h src/json_common.c
+src/basic-test_stamp: src/json_common.h src/json_common.c
 	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir}/tests/test-spec --out=${srcdir}/src ${srcdir}/tests/test-spec/basic
-
-src/json_common_stamp: src/common_h.py src/common_c.py
-	$(PYTHON) $(srcdir)/src/generate.py --gen-common --root=${srcdir} --out=${srcdir}/src
-
-src/json_common.h src/json_common.c: src/json_common_stamp
+	@touch $@
 
 src/image_spec_schema_config_schema.c \
 	src/image_spec_schema_content_descriptor.c \
@@ -107,22 +104,23 @@ src/basic_test_double_array_item.h \
 	src/basic_test_top_array_string.c \
 	src/basic_test_top_double_array_int.c \
 	src/basic_test_top_double_array_obj.c \
-	src/basic_test_top_double_array_string.c: src/basic-test-stamp
+	src/basic_test_top_double_array_string.c: src/basic-test_stamp
 
 $(HEADER_FILES): %.h: %.c src/generate.py
 
 BUILT_SOURCES = $(HEADER_FILES) $(SOURCE_FILES)
 
-libocispec_la_SOURCES = $(BUILT_SOURCES) \
-	src/read-file.c
-
 libocispec_a_SOURCES =
+
+libocispec_la_SOURCES = $(BUILT_SOURCES) \
+	src/read-file.c \
+	src/json_common.c
 
 CLEANFILES += $(HEADER_FILES) $(SOURCE_FILES)
 
 TESTS_LDADD = libocispec.la $(SELINUX_LIBS) $(YAJL_LIBS)
 
-libocispec.a: libocispec.la $(BUILT_SOURCES)
+libocispec.a: libocispec.la $(BUILT_SOURCES) src/runtime_spec_stamp src/image_spec_stamp src/image_manifest_stamp src/basic-test_stamp
 	$(LIBTOOL) --mode=link $(GCC) libocispec.la -o libocispec.a
 
 tests_test_1_SOURCES = tests/test-1.c
@@ -196,8 +194,6 @@ EXTRA_DIST = autogen.sh \
 	tests/data/top_double_array_string.json \
 	tests/test-spec \
 	src/generate.py \
-	src/common_c.py \
-	src/common_h.py \
 	src/headers.py \
 	src/helpers.py \
 	src/sources.py \
@@ -205,12 +201,12 @@ EXTRA_DIST = autogen.sh \
 	src/read-file.h \
 	src/json_common.h \
 	runtime-spec \
-	image-spec
+	image-spec \
+	src/json_common.h \
+	src/json_common.c
 
 sync:
 	(cd image-spec; git pull https://github.com/opencontainers/image-spec)
 	(cd runtime-spec; git pull https://github.com/opencontainers/runtime-spec)
-generate:
-	$(PYTHON) $(srcdir)/src/generate.py --gen-common --gen-ref --root=${srcdir} --out=${srcdir}/src ${srcdir}/runtime-spec/schema ${srcdir}/image-spec/schema
-	$(PYTHON) $(srcdir)/src/generate.py --gen-common --gen-ref --root=${srcdir}/tests/test-spec --out=${srcdir}/src ${srcdir}/tests/test-spec/imageManifestItems
-	$(PYTHON) $(srcdir)/src/generate.py --gen-common --gen-ref --root=${srcdir}/tests/test-spec --out=${srcdir}/src ${srcdir}/tests/test-spec/basic
+
+generate: src/runtime_spec_stamp src/image_spec_stamp src/image_manifest_stamp src/basic-test_stamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -116,7 +116,10 @@ libocispec_la_SOURCES = $(BUILT_SOURCES) \
 	src/read-file.c \
 	src/json_common.c
 
-CLEANFILES += $(HEADER_FILES) $(SOURCE_FILES)
+TMP_C_FILES = $(HEADER_FILES:.h=.h.tmp)
+TMP_C_FILES = $(SOURCE_FILES:.c=.c.tmp)
+
+CLEANFILES += $(HEADER_FILES) $(SOURCE_FILES) $(TMP_H_FILES) $(TMP_C_FILES)
 
 TESTS_LDADD = libocispec.la $(SELINUX_LIBS) $(YAJL_LIBS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,11 +37,23 @@ SOURCE_FILES = \
 
 HEADER_FILES = $(SOURCE_FILES:.c=.h)
 
-src/json_common.h src/json_common.c: src/common_h.py src/common_c.py
-	$(PYTHON) $(srcdir)/src/generate.py --gen-common --gen-ref --root=${srcdir} --out=${srcdir}/src ${srcdir}/runtime-spec/schema ${srcdir}/image-spec/schema
-	$(PYTHON) $(srcdir)/src/generate.py --gen-common --gen-ref --root=${srcdir}/tests/test-spec --out=${srcdir}/src ${srcdir}/tests/test-spec/imageManifestItems
-	$(PYTHON) $(srcdir)/src/generate.py --gen-common --gen-ref --root=${srcdir}/tests/test-spec --out=${srcdir}/src ${srcdir}/tests/test-spec/basic
 
+src/runtime_spec_stamp: src/json_common.h src/json_common.c
+	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir} --out=${srcdir}/src ${srcdir}/runtime-spec/schema
+
+src/image_spec_stamp: src/json_common.h src/json_common.c
+	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir} --out=${srcdir}/src ${srcdir}/image-spec/schema
+
+src/image_manifest_stamp: src/json_common.h src/json_common.c
+	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir}/tests/test-spec --out=${srcdir}/src ${srcdir}/tests/test-spec/imageManifestItems
+
+src/basic-test-stamp: src/json_common.h src/json_common.c
+	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir}/tests/test-spec --out=${srcdir}/src ${srcdir}/tests/test-spec/basic
+
+src/json_common_stamp: src/common_h.py src/common_c.py
+	$(PYTHON) $(srcdir)/src/generate.py --gen-common --root=${srcdir} --out=${srcdir}/src
+
+src/json_common.h src/json_common.c: src/json_common_stamp
 
 src/image_spec_schema_config_schema.c \
 	src/image_spec_schema_content_descriptor.c \
@@ -50,6 +62,24 @@ src/image_spec_schema_config_schema.c \
 	src/image_spec_schema_image_index_schema.c \
 	src/image_spec_schema_image_layout_schema.c \
 	src/image_spec_schema_image_manifest_schema.c \
+	src/image_spec_schema_config_schema.h \
+	src/image_spec_schema_content_descriptor.h \
+	src/image_spec_schema_defs.h \
+	src/image_spec_schema_defs_descriptor.h \
+	src/image_spec_schema_image_index_schema.h \
+	src/image_spec_schema_image_layout_schema.h \
+	src/image_spec_schema_image_manifest_schema.h: src/image_spec_stamp
+
+src/runtime_spec_schema_config_linux.h \
+	src/runtime_spec_schema_config_schema.h \
+	src/runtime_spec_schema_config_solaris.h \
+	src/runtime_spec_schema_config_vm.h \
+	src/runtime_spec_schema_config_windows.h \
+	src/runtime_spec_schema_defs.h \
+	src/runtime_spec_schema_defs_linux.h \
+	src/runtime_spec_schema_defs_vm.h \
+	src/runtime_spec_schema_defs_windows.h \
+	src/runtime_spec_schema_state_schema.h \
 	src/runtime_spec_schema_config_linux.c \
 	src/runtime_spec_schema_config_schema.c \
 	src/runtime_spec_schema_config_solaris.c \
@@ -59,21 +89,31 @@ src/image_spec_schema_config_schema.c \
 	src/runtime_spec_schema_defs_linux.c \
 	src/runtime_spec_schema_defs_vm.c \
 	src/runtime_spec_schema_defs_windows.c \
-	src/runtime_spec_schema_state_schema.c \
+	src/runtime_spec_schema_state_schema.c: src/runtime_spec_stamp
+
+src/image_manifest_items_image_manifest_items_schema.h \
+	src/image_manifest_items_image_manifest_items_schema.c: src/image_manifest_stamp
+
+src/basic_test_double_array_item.h \
+	src/basic_test_double_array.h \
+	src/basic_test_top_array_int.h \
+	src/basic_test_top_array_string.h \
+	src/basic_test_top_double_array_int.h \
+	src/basic_test_top_double_array_obj.h \
+	src/basic_test_top_double_array_string.h \
 	src/basic_test_double_array_item.c \
 	src/basic_test_double_array.c \
 	src/basic_test_top_array_int.c \
 	src/basic_test_top_array_string.c \
 	src/basic_test_top_double_array_int.c \
 	src/basic_test_top_double_array_obj.c \
-	src/basic_test_top_double_array_string.c \
-	src/image_manifest_items_image_manifest_items_schema.c: src/json_common.h
+	src/basic_test_top_double_array_string.c: src/basic-test-stamp
 
 $(HEADER_FILES): %.h: %.c src/generate.py
 
 BUILT_SOURCES = $(HEADER_FILES) $(SOURCE_FILES)
 
-libocispec_la_SOURCES = $(SOURCE_FILES) \
+libocispec_la_SOURCES = $(BUILT_SOURCES) \
 	src/read-file.c
 
 libocispec_a_SOURCES =
@@ -82,7 +122,7 @@ CLEANFILES += $(HEADER_FILES) $(SOURCE_FILES)
 
 TESTS_LDADD = libocispec.la $(SELINUX_LIBS) $(YAJL_LIBS)
 
-libocispec.a: libocispec.la
+libocispec.a: libocispec.la $(BUILT_SOURCES)
 	$(LIBTOOL) --mode=link $(GCC) libocispec.la -o libocispec.a
 
 tests_test_1_SOURCES = tests/test-1.c

--- a/src/generate.py
+++ b/src/generate.py
@@ -37,8 +37,6 @@ from collections import OrderedDict
 import helpers
 import headers
 import sources
-import common_h
-import common_c
 
 # - json suffix
 JSON_SUFFIX = ".json"
@@ -725,15 +723,6 @@ def reflection(schema_info, gen_ref):
                 reflection(reffile, True)
 
 
-def gen_common_files(out):
-    """
-    Description: generate c language for parse json map string object
-    Interface: None
-    History: 2019-06-17
-    """
-    common_h.generate_json_common_h(out)
-    common_c.generate_json_common_c(out)
-
 def handle_single_file(args, srcpath, gen_ref, schemapath):
     """
     Description: generate c language for parse json map string object
@@ -800,9 +789,6 @@ def main():
         'All schema files must be placed in root directory or sub-directory of root," \
         " and naming of C variables is started from this path'
     )
-    parser.add_argument('--gen-common',
-                        action='store_true',
-                        help='Generate json_common.c and json_common.h')
     parser.add_argument('--gen-ref',
                         action='store_true',
                         help='Generate reference file defined in schema with key \"$ref\"')
@@ -833,9 +819,6 @@ def main():
     if not os.path.exists(srcpath.name):
         os.makedirs(srcpath.name)
 
-    if args.gen_common:
-        gen_common_files(srcpath.name)
-        sys.exit(0)
     handle_files(args, srcpath)
 
 

--- a/src/generate.py
+++ b/src/generate.py
@@ -792,7 +792,7 @@ def main():
     parser = argparse.ArgumentParser(prog='generate.py',
                                      usage='%(prog)s [options] path [path ...]',
                                      description='Generate C header and source from json-schema')
-    parser.add_argument('path', nargs='+', help='File or directory to parse')
+    parser.add_argument('path', nargs='*', help='File or directory to parse')
     parser.add_argument(
         '--root',
         required=True,
@@ -835,6 +835,7 @@ def main():
 
     if args.gen_common:
         gen_common_files(srcpath.name)
+        sys.exit(0)
     handle_files(args, srcpath)
 
 

--- a/src/json_common.c
+++ b/src/json_common.c
@@ -1,124 +1,130 @@
-# define _GNU_SOURCE
-# include <stdio.h>
-# include <string.h>
-# include <errno.h>
-# include <limits.h>
-# include "json_common.h"
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include "json_common.h"
 
 #define YAJL_GET_OBJECT_NO_CHECK(v) (&(v)->u.object)
 #define YAJL_GET_STRING_NO_CHECK(v) ((v)->u.string)
 
-# define MAX_NUM_STR_LEN 21
+#define MAX_NUM_STR_LEN 21
 
 static yajl_gen_status gen_yajl_val (yajl_val obj, yajl_gen g, parser_error *err);
 
-static yajl_gen_status gen_yajl_val_obj (yajl_val obj, yajl_gen g, parser_error *err)
+static yajl_gen_status
+gen_yajl_val_obj (yajl_val obj, yajl_gen g, parser_error *err)
 {
-    size_t i;
-    yajl_gen_status stat = yajl_gen_status_ok;
+  size_t i;
+  yajl_gen_status stat = yajl_gen_status_ok;
 
-    stat = yajl_gen_map_open (g);
-    if (yajl_gen_status_ok != stat)
-        GEN_SET_ERROR_AND_RETURN (stat, err);
+  stat = yajl_gen_map_open (g);
+  if (yajl_gen_status_ok != stat)
+    GEN_SET_ERROR_AND_RETURN (stat, err);
 
-    for (i = 0; i < obj->u.object.len; i++)
+  for (i = 0; i < obj->u.object.len; i++)
     {
-        stat = yajl_gen_string (g, (const unsigned char *) obj->u.object.keys[i], strlen (obj->u.object.keys[i]));
-        if (yajl_gen_status_ok != stat)
-            GEN_SET_ERROR_AND_RETURN (stat, err);
-        stat = gen_yajl_val (obj->u.object.values[i], g, err);
-        if (yajl_gen_status_ok != stat)
-            GEN_SET_ERROR_AND_RETURN (stat, err);
+      stat = yajl_gen_string (g, (const unsigned char *) obj->u.object.keys[i], strlen (obj->u.object.keys[i]));
+      if (yajl_gen_status_ok != stat)
+        GEN_SET_ERROR_AND_RETURN (stat, err);
+      stat = gen_yajl_val (obj->u.object.values[i], g, err);
+      if (yajl_gen_status_ok != stat)
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
-    stat = yajl_gen_map_close (g);
-    if (yajl_gen_status_ok != stat)
-        GEN_SET_ERROR_AND_RETURN (stat, err);
-    return yajl_gen_status_ok;
+  stat = yajl_gen_map_close (g);
+  if (yajl_gen_status_ok != stat)
+    GEN_SET_ERROR_AND_RETURN (stat, err);
+  return yajl_gen_status_ok;
 }
 
-static yajl_gen_status gen_yajl_val_array (yajl_val arr, yajl_gen g, parser_error *err)
+static yajl_gen_status
+gen_yajl_val_array (yajl_val arr, yajl_gen g, parser_error *err)
 {
-    size_t i;
-    yajl_gen_status stat = yajl_gen_status_ok;
+  size_t i;
+  yajl_gen_status stat = yajl_gen_status_ok;
 
-    stat = yajl_gen_array_open (g);
-    if (yajl_gen_status_ok != stat)
-        GEN_SET_ERROR_AND_RETURN (stat, err);
+  stat = yajl_gen_array_open (g);
+  if (yajl_gen_status_ok != stat)
+    GEN_SET_ERROR_AND_RETURN (stat, err);
 
-    for (i = 0; i < arr->u.array.len; i++)
+  for (i = 0; i < arr->u.array.len; i++)
     {
-        stat = gen_yajl_val (arr->u.array.values[i], g, err);
-        if (yajl_gen_status_ok != stat)
-            GEN_SET_ERROR_AND_RETURN (stat, err);
+      stat = gen_yajl_val (arr->u.array.values[i], g, err);
+      if (yajl_gen_status_ok != stat)
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
-    stat = yajl_gen_array_close (g);
-    if (yajl_gen_status_ok != stat)
-        GEN_SET_ERROR_AND_RETURN (stat, err);
-    return yajl_gen_status_ok;
+  stat = yajl_gen_array_close (g);
+  if (yajl_gen_status_ok != stat)
+    GEN_SET_ERROR_AND_RETURN (stat, err);
+  return yajl_gen_status_ok;
 }
 
-static yajl_gen_status gen_yajl_val (yajl_val obj, yajl_gen g, parser_error *err)
+static yajl_gen_status
+gen_yajl_val (yajl_val obj, yajl_gen g, parser_error *err)
 {
-    yajl_gen_status __stat = yajl_gen_status_ok;
-    char *__tstr;
+  yajl_gen_status __stat = yajl_gen_status_ok;
+  char *__tstr;
 
-    switch(obj->type)
+  switch (obj->type)
     {
-        case yajl_t_string:
-            __tstr = YAJL_GET_STRING (obj);
-            if (__tstr == NULL) {
-                return __stat;
-            }
-            __stat = yajl_gen_string (g, (const unsigned char *) __tstr, strlen (__tstr));
-            if (yajl_gen_status_ok != __stat)
-                GEN_SET_ERROR_AND_RETURN (__stat, err);
-            return yajl_gen_status_ok;
-        case yajl_t_number:
-            __tstr = YAJL_GET_NUMBER (obj);
-            if (__tstr == NULL) {
-                return __stat;
-            }
-            __stat = yajl_gen_number (g, __tstr, strlen (__tstr));
-            if (yajl_gen_status_ok != __stat)
-                GEN_SET_ERROR_AND_RETURN (__stat, err);
-            return yajl_gen_status_ok;
-        case yajl_t_object:
-            return gen_yajl_val_obj (obj, g, err);
-        case yajl_t_array:
-            return gen_yajl_val_array (obj, g, err);
-        case yajl_t_true:
-            return yajl_gen_bool (g, true);
-        case yajl_t_false:
-            return yajl_gen_bool (g, false);
-        case yajl_t_null:
-        case yajl_t_any:
-            return __stat;
-    }
-    return __stat;
-}
-
-yajl_gen_status gen_yajl_object_residual (yajl_val obj, yajl_gen g, parser_error *err)
-{
-    size_t i;
-    yajl_gen_status stat = yajl_gen_status_ok;
-
-    for (i = 0; i < obj->u.object.len; i++)
-    {
-        if (obj->u.object.keys[i] == NULL)
+    case yajl_t_string:
+      __tstr = YAJL_GET_STRING (obj);
+      if (__tstr == NULL)
         {
-            continue;
+          return __stat;
         }
-        stat = yajl_gen_string (g, (const unsigned char *) obj->u.object.keys[i], strlen (obj->u.object.keys[i]));
-        if (yajl_gen_status_ok != stat)
-            GEN_SET_ERROR_AND_RETURN (stat, err);
-        stat = gen_yajl_val (obj->u.object.values[i], g, err);
-        if (yajl_gen_status_ok != stat)
-            GEN_SET_ERROR_AND_RETURN (stat, err);
+      __stat = yajl_gen_string (g, (const unsigned char *) __tstr, strlen (__tstr));
+      if (yajl_gen_status_ok != __stat)
+        GEN_SET_ERROR_AND_RETURN (__stat, err);
+      return yajl_gen_status_ok;
+    case yajl_t_number:
+      __tstr = YAJL_GET_NUMBER (obj);
+      if (__tstr == NULL)
+        {
+          return __stat;
+        }
+      __stat = yajl_gen_number (g, __tstr, strlen (__tstr));
+      if (yajl_gen_status_ok != __stat)
+        GEN_SET_ERROR_AND_RETURN (__stat, err);
+      return yajl_gen_status_ok;
+    case yajl_t_object:
+      return gen_yajl_val_obj (obj, g, err);
+    case yajl_t_array:
+      return gen_yajl_val_array (obj, g, err);
+    case yajl_t_true:
+      return yajl_gen_bool (g, true);
+    case yajl_t_false:
+      return yajl_gen_bool (g, false);
+    case yajl_t_null:
+    case yajl_t_any:
+      return __stat;
+    }
+  return __stat;
+}
+
+yajl_gen_status
+gen_yajl_object_residual (yajl_val obj, yajl_gen g, parser_error *err)
+{
+  size_t i;
+  yajl_gen_status stat = yajl_gen_status_ok;
+
+  for (i = 0; i < obj->u.object.len; i++)
+    {
+      if (obj->u.object.keys[i] == NULL)
+        {
+          continue;
+        }
+      stat = yajl_gen_string (g, (const unsigned char *) obj->u.object.keys[i], strlen (obj->u.object.keys[i]));
+      if (yajl_gen_status_ok != stat)
+        GEN_SET_ERROR_AND_RETURN (stat, err);
+      stat = gen_yajl_val (obj->u.object.values[i], g, err);
+      if (yajl_gen_status_ok != stat)
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
-    return yajl_gen_status_ok;
+  return yajl_gen_status_ok;
 }
 
 yajl_gen_status
@@ -130,8 +136,7 @@ map_uint (void *ctx, long long unsigned int num)
   ret = snprintf (numstr, sizeof (numstr), "%llu", num);
   if (ret < 0 || (size_t) ret >= sizeof (numstr))
     return yajl_gen_in_error_state;
-  return yajl_gen_number ((yajl_gen) ctx, (const char *) numstr,
-			  strlen (numstr));
+  return yajl_gen_number ((yajl_gen) ctx, (const char *) numstr, strlen (numstr));
 }
 
 yajl_gen_status
@@ -143,22 +148,18 @@ map_int (void *ctx, long long int num)
   ret = snprintf (numstr, sizeof (numstr), "%lld", num);
   if (ret < 0 || (size_t) ret >= sizeof (numstr))
     return yajl_gen_in_error_state;
-  return yajl_gen_number ((yajl_gen) ctx, (const char *) numstr,
-			  strlen (numstr));
+  return yajl_gen_number ((yajl_gen) ctx, (const char *) numstr, strlen (numstr));
 }
 
-
 bool
-json_gen_init (yajl_gen * g, const struct parser_context *ctx)
+json_gen_init (yajl_gen *g, const struct parser_context *ctx)
 {
   *g = yajl_gen_alloc (NULL);
   if (NULL == *g)
     return false;
 
-  yajl_gen_config (*g, yajl_gen_beautify,
-		   (int) (!(ctx->options & OPT_GEN_SIMPLIFY)));
-  yajl_gen_config (*g, yajl_gen_validate_utf8,
-		   (int) (!(ctx->options & OPT_GEN_NO_VALIDATE_UTF8)));
+  yajl_gen_config (*g, yajl_gen_beautify, (int) (! (ctx->options & OPT_GEN_SIMPLIFY)));
+  yajl_gen_config (*g, yajl_gen_validate_utf8, (int) (! (ctx->options & OPT_GEN_NO_VALIDATE_UTF8)));
   return true;
 }
 
@@ -172,26 +173,26 @@ get_val (yajl_val tree, const char *name, yajl_type type)
 char *
 safe_strdup (const char *src)
 {
-    char *dst = NULL;
+  char *dst = NULL;
 
-    if (src == NULL)
-        return NULL;
-    dst = strdup (src);
-    if (dst == NULL)
-        abort ();
-    return dst;
+  if (src == NULL)
+    return NULL;
+  dst = strdup (src);
+  if (dst == NULL)
+    abort ();
+  return dst;
 }
 
 void *
 safe_malloc (size_t size)
 {
-    void *ret = NULL;
-    if (size == 0)
-        abort ();
-    ret = calloc (1, size);
-    if (ret == NULL)
-        abort ();
-    return ret;
+  void *ret = NULL;
+  if (size == 0)
+    abort ();
+  ret = calloc (1, size);
+  if (ret == NULL)
+    abort ();
+  return ret;
 }
 
 int
@@ -208,7 +209,6 @@ common_safe_double (const char *numstr, double *converted)
   if (errno > 0)
     return -errno;
 
-
   if (err_str == NULL || err_str == numstr || *err_str != '\0')
     return -EINVAL;
 
@@ -217,7 +217,7 @@ common_safe_double (const char *numstr, double *converted)
 }
 
 int
-common_safe_uint8 (const char *numstr, uint8_t * converted)
+common_safe_uint8 (const char *numstr, uint8_t *converted)
 {
   char *err = NULL;
   unsigned long int uli;
@@ -241,7 +241,7 @@ common_safe_uint8 (const char *numstr, uint8_t * converted)
 }
 
 int
-common_safe_uint16 (const char *numstr, uint16_t * converted)
+common_safe_uint16 (const char *numstr, uint16_t *converted)
 {
   char *err = NULL;
   unsigned long int uli;
@@ -265,7 +265,7 @@ common_safe_uint16 (const char *numstr, uint16_t * converted)
 }
 
 int
-common_safe_uint32 (const char *numstr, uint32_t * converted)
+common_safe_uint32 (const char *numstr, uint32_t *converted)
 {
   char *err = NULL;
   unsigned long long int ull;
@@ -289,7 +289,7 @@ common_safe_uint32 (const char *numstr, uint32_t * converted)
 }
 
 int
-common_safe_uint64 (const char *numstr, uint64_t * converted)
+common_safe_uint64 (const char *numstr, uint64_t *converted)
 {
   char *err = NULL;
   unsigned long long int ull;
@@ -334,7 +334,7 @@ common_safe_uint (const char *numstr, unsigned int *converted)
 }
 
 int
-common_safe_int8 (const char *numstr, int8_t * converted)
+common_safe_int8 (const char *numstr, int8_t *converted)
 {
   char *err = NULL;
   long int li;
@@ -360,7 +360,7 @@ common_safe_int8 (const char *numstr, int8_t * converted)
 }
 
 int
-common_safe_int16 (const char *numstr, int16_t * converted)
+common_safe_int16 (const char *numstr, int16_t *converted)
 {
   char *err = NULL;
   long int li;
@@ -384,7 +384,7 @@ common_safe_int16 (const char *numstr, int16_t * converted)
 }
 
 int
-common_safe_int32 (const char *numstr, int32_t * converted)
+common_safe_int32 (const char *numstr, int32_t *converted)
 {
   char *err = NULL;
   long long int lli;
@@ -409,7 +409,7 @@ common_safe_int32 (const char *numstr, int32_t * converted)
 }
 
 int
-common_safe_int64 (const char *numstr, int64_t * converted)
+common_safe_int64 (const char *numstr, int64_t *converted)
 {
   char *err = NULL;
   long long int lli;
@@ -454,15 +454,14 @@ common_safe_int (const char *numstr, int *converted)
 }
 
 yajl_gen_status
-gen_json_map_int_int (void *ctx, const json_map_int_int * map,
-		      const struct parser_context *ptx, parser_error * err)
+gen_json_map_int_int (void *ctx, const json_map_int_int *map, const struct parser_context *ptx, parser_error *err)
 {
   yajl_gen_status stat = yajl_gen_status_ok;
   yajl_gen g = (yajl_gen) ctx;
   size_t len = 0, i = 0;
   if (map != NULL)
     len = map->len;
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 0);
   stat = yajl_gen_map_open ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
@@ -471,35 +470,31 @@ gen_json_map_int_int (void *ctx, const json_map_int_int * map,
     {
       char numstr[MAX_NUM_STR_LEN];
       int nret;
-      nret =
-	snprintf (numstr, sizeof (numstr), "%lld",
-		  (long long int) map->keys[i]);
+      nret = snprintf (numstr, sizeof (numstr), "%lld", (long long int) map->keys[i]);
       if (nret < 0 || (size_t) nret >= sizeof (numstr))
-	{
-	  if (!*err)
+        {
+          if (! *err)
             *err = strdup ("Error to print string");
-	  return yajl_gen_in_error_state;
-	}
-      stat =
-	yajl_gen_string ((yajl_gen) g, (const unsigned char *) numstr,
-			 strlen (numstr));
+          return yajl_gen_in_error_state;
+        }
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) numstr, strlen (numstr));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
       stat = map_int (g, map->values[i]);
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
   stat = yajl_gen_map_close ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
     GEN_SET_ERROR_AND_RETURN (stat, err);
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 1);
   return yajl_gen_status_ok;
 }
 
 void
-free_json_map_int_int (json_map_int_int * map)
+free_json_map_int_int (json_map_int_int *map)
 {
   if (map != NULL)
     {
@@ -513,15 +508,13 @@ free_json_map_int_int (json_map_int_int * map)
 
 define_cleaner_function (json_map_int_int *, free_json_map_int_int)
 
-json_map_int_int *
-make_json_map_int_int (yajl_val src, const struct parser_context *ctx,
-		       parser_error * err)
+    json_map_int_int *make_json_map_int_int (yajl_val src, const struct parser_context *ctx, parser_error *err)
 {
-  __auto_cleanup(free_json_map_int_int) json_map_int_int *ret = NULL;
+  __auto_cleanup (free_json_map_int_int) json_map_int_int *ret = NULL;
   size_t i;
   size_t len;
 
-  (void) ctx;			/* Silence compiler warning.  */
+  (void) ctx; /* Silence compiler warning.  */
 
   if (src == NULL || YAJL_GET_OBJECT (src) == NULL)
     return NULL;
@@ -558,8 +551,8 @@ make_json_map_int_int (yajl_val src, const struct parser_context *ctx,
           int invalid = common_safe_int (srckey, &(ret->keys[i]));
           if (invalid)
             {
-              if (*err == NULL && asprintf (err, "Invalid key '%s' with type 'int': %s",
-                    srckey, strerror (-invalid)) < 0)
+              if (*err == NULL
+                  && asprintf (err, "Invalid key '%s' with type 'int': %s", srckey, strerror (-invalid)) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -570,10 +563,9 @@ make_json_map_int_int (yajl_val src, const struct parser_context *ctx,
       if (srcval != NULL)
         {
           int invalid;
-          if (!YAJL_IS_NUMBER (srcval))
+          if (! YAJL_IS_NUMBER (srcval))
             {
-              if (*err == NULL && asprintf (err,
-                    "Invalid value with type 'int' for key '%s'", srckey) < 0)
+              if (*err == NULL && asprintf (err, "Invalid value with type 'int' for key '%s'", srckey) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -582,8 +574,8 @@ make_json_map_int_int (yajl_val src, const struct parser_context *ctx,
           invalid = common_safe_int (YAJL_GET_NUMBER (srcval), &(ret->values[i]));
           if (invalid)
             {
-              if (*err == NULL && asprintf (err, "Invalid value with type 'int' for key '%s': %s",
-                    srckey, strerror (-invalid)) < 0)
+              if (*err == NULL
+                  && asprintf (err, "Invalid value with type 'int' for key '%s': %s", srckey, strerror (-invalid)) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -595,7 +587,7 @@ make_json_map_int_int (yajl_val src, const struct parser_context *ctx,
 }
 
 int
-append_json_map_int_int (json_map_int_int * map, int key, int val)
+append_json_map_int_int (json_map_int_int *map, int key, int val)
 {
   size_t len;
   __auto_free int *keys = NULL;
@@ -636,15 +628,14 @@ append_json_map_int_int (json_map_int_int * map, int key, int val)
 }
 
 yajl_gen_status
-gen_json_map_int_bool (void *ctx, const json_map_int_bool * map,
-		       const struct parser_context *ptx, parser_error * err)
+gen_json_map_int_bool (void *ctx, const json_map_int_bool *map, const struct parser_context *ptx, parser_error *err)
 {
   yajl_gen_status stat = yajl_gen_status_ok;
   yajl_gen g = (yajl_gen) ctx;
   size_t len = 0, i = 0;
   if (map != NULL)
     len = map->len;
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 0);
   stat = yajl_gen_map_open ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
@@ -653,44 +644,40 @@ gen_json_map_int_bool (void *ctx, const json_map_int_bool * map,
     {
       char numstr[MAX_NUM_STR_LEN];
       int nret;
-      nret =
-	snprintf (numstr, sizeof (numstr), "%lld",
-		  (long long int) map->keys[i]);
+      nret = snprintf (numstr, sizeof (numstr), "%lld", (long long int) map->keys[i]);
       if (nret < 0 || (size_t) nret >= sizeof (numstr))
-	{
-	  if (!*err)
+        {
+          if (! *err)
             *err = strdup ("Error to print string");
-	  return yajl_gen_in_error_state;
-	}
-      stat =
-	yajl_gen_string ((yajl_gen) g, (const unsigned char *) numstr,
-			 strlen (numstr));
+          return yajl_gen_in_error_state;
+        }
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) numstr, strlen (numstr));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
       stat = yajl_gen_bool ((yajl_gen) g, (int) (map->values[i]));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
   stat = yajl_gen_map_close ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
     GEN_SET_ERROR_AND_RETURN (stat, err);
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 1);
   return yajl_gen_status_ok;
 }
 
 void
-free_json_map_int_bool (json_map_int_bool * map)
+free_json_map_int_bool (json_map_int_bool *map)
 {
   if (map != NULL)
     {
       size_t i;
       for (i = 0; i < map->len; i++)
-	{
-	  // No need to free key for type int
-	  // No need to free value for type bool
-	}
+        {
+          // No need to free key for type int
+          // No need to free value for type bool
+        }
       free (map->keys);
       map->keys = NULL;
       free (map->values);
@@ -701,15 +688,13 @@ free_json_map_int_bool (json_map_int_bool * map)
 
 define_cleaner_function (json_map_int_bool *, free_json_map_int_bool)
 
-json_map_int_bool *
-make_json_map_int_bool (yajl_val src, const struct parser_context *ctx,
-			parser_error * err)
+    json_map_int_bool *make_json_map_int_bool (yajl_val src, const struct parser_context *ctx, parser_error *err)
 {
-  __auto_cleanup(free_json_map_int_bool) json_map_int_bool *ret = NULL;
+  __auto_cleanup (free_json_map_int_bool) json_map_int_bool *ret = NULL;
   size_t i;
   size_t len;
 
-  (void) ctx;			/* Silence compiler warning.  */
+  (void) ctx; /* Silence compiler warning.  */
 
   if (src == NULL || YAJL_GET_OBJECT (src) == NULL)
     return NULL;
@@ -743,8 +728,8 @@ make_json_map_int_bool (yajl_val src, const struct parser_context *ctx,
           int invalid = common_safe_int (srckey, &(ret->keys[i]));
           if (invalid)
             {
-              if (*err == NULL && asprintf (err, "Invalid key '%s' with type 'int': %s",
-                    srckey, strerror (-invalid)) < 0)
+              if (*err == NULL
+                  && asprintf (err, "Invalid key '%s' with type 'int': %s", srckey, strerror (-invalid)) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -760,8 +745,7 @@ make_json_map_int_bool (yajl_val src, const struct parser_context *ctx,
             ret->values[i] = false;
           else
             {
-              if (*err == NULL && asprintf (err,
-                    "Invalid value with type 'bool' for key '%s'", srckey) < 0)
+              if (*err == NULL && asprintf (err, "Invalid value with type 'bool' for key '%s'", srckey) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -773,7 +757,7 @@ make_json_map_int_bool (yajl_val src, const struct parser_context *ctx,
 }
 
 int
-append_json_map_int_bool (json_map_int_bool * map, int key, bool val)
+append_json_map_int_bool (json_map_int_bool *map, int key, bool val)
 {
   size_t len;
   __auto_free int *keys = NULL;
@@ -782,8 +766,7 @@ append_json_map_int_bool (json_map_int_bool * map, int key, bool val)
   if (map == NULL)
     return -1;
 
-  if ((SIZE_MAX / sizeof (int) - 1) < map->len
-      || (SIZE_MAX / sizeof (bool) - 1) < map->len)
+  if ((SIZE_MAX / sizeof (int) - 1) < map->len || (SIZE_MAX / sizeof (bool) - 1) < map->len)
     return -1;
 
   len = map->len + 1;
@@ -815,15 +798,14 @@ append_json_map_int_bool (json_map_int_bool * map, int key, bool val)
 }
 
 yajl_gen_status
-gen_json_map_int_string (void *ctx, const json_map_int_string * map,
-			 const struct parser_context *ptx, parser_error * err)
+gen_json_map_int_string (void *ctx, const json_map_int_string *map, const struct parser_context *ptx, parser_error *err)
 {
   yajl_gen_status stat = yajl_gen_status_ok;
   yajl_gen g = (yajl_gen) ctx;
   size_t len = 0, i = 0;
   if (map != NULL)
     len = map->len;
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 0);
 
   stat = yajl_gen_map_open ((yajl_gen) g);
@@ -833,48 +815,41 @@ gen_json_map_int_string (void *ctx, const json_map_int_string * map,
     {
       char numstr[MAX_NUM_STR_LEN];
       int nret;
-      nret =
-	snprintf (numstr, sizeof (numstr), "%lld",
-		  (long long int) map->keys[i]);
+      nret = snprintf (numstr, sizeof (numstr), "%lld", (long long int) map->keys[i]);
       if (nret < 0 || (size_t) nret >= sizeof (numstr))
-	{
-	  if (!*err)
+        {
+          if (! *err)
             *err = strdup ("Error to print string");
-	  return yajl_gen_in_error_state;
-	}
-      stat =
-	yajl_gen_string ((yajl_gen) g, (const unsigned char *) numstr,
-			 strlen (numstr));
+          return yajl_gen_in_error_state;
+        }
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) numstr, strlen (numstr));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
-      stat =
-	yajl_gen_string ((yajl_gen) g,
-			 (const unsigned char *) (map->values[i]),
-			 strlen (map->values[i]));
+        GEN_SET_ERROR_AND_RETURN (stat, err);
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->values[i]), strlen (map->values[i]));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
   stat = yajl_gen_map_close ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
     GEN_SET_ERROR_AND_RETURN (stat, err);
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 1);
   return yajl_gen_status_ok;
 }
 
 void
-free_json_map_int_string (json_map_int_string * map)
+free_json_map_int_string (json_map_int_string *map)
 {
   if (map != NULL)
     {
       size_t i;
       for (i = 0; i < map->len; i++)
-	{
-	  // No need to free key for type int
-	  free (map->values[i]);
-	  map->values[i] = NULL;
-	}
+        {
+          // No need to free key for type int
+          free (map->values[i]);
+          map->values[i] = NULL;
+        }
       free (map->keys);
       map->keys = NULL;
       free (map->values);
@@ -885,18 +860,16 @@ free_json_map_int_string (json_map_int_string * map)
 
 define_cleaner_function (json_map_int_string *, free_json_map_int_string)
 
-json_map_int_string *
-make_json_map_int_string (yajl_val src, const struct parser_context *ctx,
-			  parser_error * err)
+    json_map_int_string *make_json_map_int_string (yajl_val src, const struct parser_context *ctx, parser_error *err)
 {
-  __auto_cleanup(free_json_map_int_string) json_map_int_string *ret = NULL;
+  __auto_cleanup (free_json_map_int_string) json_map_int_string *ret = NULL;
   size_t i;
   size_t len;
 
   if (src == NULL || YAJL_GET_OBJECT (src) == NULL)
     return NULL;
 
-  (void) ctx;			/* Silence compiler warning.  */
+  (void) ctx; /* Silence compiler warning.  */
 
   len = YAJL_GET_OBJECT_NO_CHECK (src)->len;
 
@@ -932,8 +905,8 @@ make_json_map_int_string (yajl_val src, const struct parser_context *ctx,
           invalid = common_safe_int (srckey, &(ret->keys[i]));
           if (invalid)
             {
-              if (*err == NULL && asprintf (err, "Invalid key '%s' with type 'int': %s",
-                    srckey, strerror (-invalid)) < 0)
+              if (*err == NULL
+                  && asprintf (err, "Invalid key '%s' with type 'int': %s", srckey, strerror (-invalid)) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -943,10 +916,9 @@ make_json_map_int_string (yajl_val src, const struct parser_context *ctx,
 
       if (srcval != NULL)
         {
-          if (!YAJL_IS_STRING (srcval))
+          if (! YAJL_IS_STRING (srcval))
             {
-              if (*err == NULL && asprintf (err,
-                   "Invalid value with type 'string' for key '%s'", srckey) < 0)
+              if (*err == NULL && asprintf (err, "Invalid value with type 'string' for key '%s'", srckey) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -960,8 +932,7 @@ make_json_map_int_string (yajl_val src, const struct parser_context *ctx,
 }
 
 int
-append_json_map_int_string (json_map_int_string * map, int key,
-			    const char *val)
+append_json_map_int_string (json_map_int_string *map, int key, const char *val)
 {
   size_t len;
   int *keys = NULL;
@@ -971,8 +942,7 @@ append_json_map_int_string (json_map_int_string * map, int key,
   if (map == NULL)
     return -1;
 
-  if ((SIZE_MAX / sizeof (int) - 1) < map->len
-      || (SIZE_MAX / sizeof (char *) - 1) < map->len)
+  if ((SIZE_MAX / sizeof (int) - 1) < map->len || (SIZE_MAX / sizeof (char *) - 1) < map->len)
     return -1;
 
   len = map->len + 1;
@@ -998,50 +968,47 @@ append_json_map_int_string (json_map_int_string * map, int key,
 }
 
 yajl_gen_status
-gen_json_map_string_int (void *ctx, const json_map_string_int * map,
-			 const struct parser_context *ptx, parser_error * err)
+gen_json_map_string_int (void *ctx, const json_map_string_int *map, const struct parser_context *ptx, parser_error *err)
 {
   yajl_gen_status stat = yajl_gen_status_ok;
   yajl_gen g = (yajl_gen) ctx;
   size_t len = 0, i = 0;
   if (map != NULL)
     len = map->len;
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 0);
   stat = yajl_gen_map_open ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
     GEN_SET_ERROR_AND_RETURN (stat, err);
   for (i = 0; i < len; i++)
     {
-      stat =
-	yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->keys[i]),
-			 strlen (map->keys[i]));
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->keys[i]), strlen (map->keys[i]));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
       stat = map_int (g, map->values[i]);
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
   stat = yajl_gen_map_close ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
     GEN_SET_ERROR_AND_RETURN (stat, err);
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 1);
   return yajl_gen_status_ok;
 }
 
 void
-free_json_map_string_int (json_map_string_int * map)
+free_json_map_string_int (json_map_string_int *map)
 {
   if (map != NULL)
     {
       size_t i;
       for (i = 0; i < map->len; i++)
-	{
-	  free (map->keys[i]);
-	  map->keys[i] = NULL;
-	}
+        {
+          free (map->keys[i]);
+          map->keys[i] = NULL;
+        }
       free (map->keys);
       map->keys = NULL;
       free (map->values);
@@ -1052,15 +1019,13 @@ free_json_map_string_int (json_map_string_int * map)
 
 define_cleaner_function (json_map_string_int *, free_json_map_string_int)
 
-json_map_string_int *
-make_json_map_string_int (yajl_val src, const struct parser_context *ctx,
-			  parser_error * err)
+    json_map_string_int *make_json_map_string_int (yajl_val src, const struct parser_context *ctx, parser_error *err)
 {
-  __auto_cleanup(free_json_map_string_int) json_map_string_int *ret = NULL;
+  __auto_cleanup (free_json_map_string_int) json_map_string_int *ret = NULL;
   size_t i;
   size_t len;
 
-  (void) ctx;			/* Silence compiler warning.  */
+  (void) ctx; /* Silence compiler warning.  */
 
   if (src == NULL || YAJL_GET_OBJECT (src) == NULL)
     return NULL;
@@ -1104,10 +1069,9 @@ make_json_map_string_int (yajl_val src, const struct parser_context *ctx,
       if (srcval != NULL)
         {
           int invalid;
-          if (!YAJL_IS_NUMBER (srcval))
+          if (! YAJL_IS_NUMBER (srcval))
             {
-              if (*err == NULL && asprintf (err,
-                    "Invalid value with type 'int' for key '%s'", srckey) < 0)
+              if (*err == NULL && asprintf (err, "Invalid value with type 'int' for key '%s'", srckey) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -1116,8 +1080,8 @@ make_json_map_string_int (yajl_val src, const struct parser_context *ctx,
           invalid = common_safe_int (YAJL_GET_NUMBER (srcval), &(ret->values[i]));
           if (invalid)
             {
-              if (*err == NULL && asprintf (err, "Invalid value with type 'int' for key '%s': %s",
-                    srckey, strerror (-invalid)) < 0)
+              if (*err == NULL
+                  && asprintf (err, "Invalid value with type 'int' for key '%s': %s", srckey, strerror (-invalid)) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -1129,8 +1093,7 @@ make_json_map_string_int (yajl_val src, const struct parser_context *ctx,
 }
 
 int
-append_json_map_string_int (json_map_string_int * map, const char *key,
-			    int val)
+append_json_map_string_int (json_map_string_int *map, const char *key, int val)
 {
   size_t len;
   char **keys = NULL;
@@ -1140,8 +1103,7 @@ append_json_map_string_int (json_map_string_int * map, const char *key,
   if (map == NULL)
     return -1;
 
-  if ((SIZE_MAX / sizeof (char *) - 1) < map->len
-      || (SIZE_MAX / sizeof (int) - 1) < map->len)
+  if ((SIZE_MAX / sizeof (char *) - 1) < map->len || (SIZE_MAX / sizeof (int) - 1) < map->len)
     return -1;
 
   len = map->len + 1;
@@ -1165,185 +1127,184 @@ append_json_map_string_int (json_map_string_int * map, const char *key,
 }
 
 yajl_gen_status
-gen_json_map_string_int64 (void *ctx, const json_map_string_int64 *map,
-                           const struct parser_context *ptx, parser_error *err)
-{
-    yajl_gen_status stat = yajl_gen_status_ok;
-    yajl_gen g = (yajl_gen) ctx;
-    size_t len = 0, i = 0;
-    if (map != NULL)
-        len = map->len;
-    if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
-        yajl_gen_config (g, yajl_gen_beautify, 0);
-    stat = yajl_gen_map_open ((yajl_gen)g);
-    if (yajl_gen_status_ok != stat)
-        GEN_SET_ERROR_AND_RETURN (stat, err);
-
-    for (i = 0; i < len; i++)
-    {
-        stat = yajl_gen_string ((yajl_gen)g, (const unsigned char *)(map->keys[i]), strlen (map->keys[i]));
-        if (yajl_gen_status_ok != stat)
-            GEN_SET_ERROR_AND_RETURN (stat, err);
-        stat = map_int (g, map->values[i]);
-        if (yajl_gen_status_ok != stat)
-            GEN_SET_ERROR_AND_RETURN (stat, err);
-    }
-
-    stat = yajl_gen_map_close ((yajl_gen)g);
-    if (yajl_gen_status_ok != stat)
-        GEN_SET_ERROR_AND_RETURN (stat, err);
-    if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
-        yajl_gen_config (g, yajl_gen_beautify, 1);
-    return yajl_gen_status_ok;
-}
-
-void
-free_json_map_string_int64 (json_map_string_int64 *map)
-{
-    if (map != NULL)
-    {
-        size_t i;
-        for (i = 0; i < map->len; i++)
-        {
-            free (map->keys[i]);
-            map->keys[i] = NULL;
-        }
-        free (map->keys);
-        map->keys = NULL;
-        free (map->values);
-        map->values = NULL;
-        free (map);
-    }
-}
-
-define_cleaner_function (json_map_string_int64 *, free_json_map_string_int64)
-
-json_map_string_int64 *
-make_json_map_string_int64 (yajl_val src, const struct parser_context *ctx, parser_error *err)
-{
-    __auto_cleanup(free_json_map_string_int64) json_map_string_int64 *ret = NULL;
-
-    (void) ctx;  /* Silence compiler warning.  */
-
-    if (src != NULL && YAJL_GET_OBJECT (src) != NULL)
-    {
-        size_t i;
-        size_t len = YAJL_GET_OBJECT (src)->len;
-        ret = safe_malloc (sizeof(*ret));
-        ret->len = len;
-        ret->keys = safe_malloc ((len + 1) * sizeof (char *));
-        ret->values = safe_malloc ((len + 1) * sizeof (int64_t));
-        for (i = 0; i < len; i++)
-        {
-            const char *srckey = YAJL_GET_OBJECT (src)->keys[i];
-            yajl_val srcval = YAJL_GET_OBJECT (src)->values[i];
-            ret->keys[i] = safe_strdup (srckey ? srckey : "");
-
-            if (srcval != NULL)
-            {
-                int64_t invalid;
-                if (!YAJL_IS_NUMBER (srcval))
-                {
-                    if (*err == NULL && asprintf (err, "Invalid value with type 'int' for key '%s'", srckey) < 0)
-                    {
-                        *(err) = safe_strdup ("error allocating memory");
-                    }
-                    return NULL;
-                }
-                invalid = common_safe_int64 (YAJL_GET_NUMBER (srcval), &(ret->values[i]));
-                if (invalid)
-                {
-                    if (*err == NULL && asprintf (err, "Invalid value with type 'int' for key '%s': %s", srckey, strerror(-invalid)) < 0)
-                    {
-                        *(err) = safe_strdup ("error allocating memory");
-                    }
-                    return NULL;
-                }
-            }
-        }
-    }
-    return move_ptr (ret);
-}
-int
-append_json_map_string_int64 (json_map_string_int64 *map, const char *key, int64_t val)
-{
-    size_t len;
-    char **keys = NULL;
-    int64_t *vals = NULL;
-
-    if (map == NULL)
-        return -1;
-
-    if ((SIZE_MAX / sizeof (char *) - 1) < map->len || (SIZE_MAX / sizeof (int) - 1) < map->len)
-        return -1;
-
-    len = map->len + 1;
-    keys = safe_malloc (len * sizeof(char *));
-    vals = safe_malloc (len * sizeof(int64_t));
-
-    if (map->len)
-    {
-        (void)memcpy (keys, map->keys, map->len * sizeof (char *));
-        (void)memcpy (vals, map->values, map->len * sizeof (int64_t));
-    }
-    free (map->keys);
-    map->keys = keys;
-    free (map->values);
-    map->values = vals;
-    map->keys[map->len] = safe_strdup (key ? key : "");
-    map->values[map->len] = val;
-
-    map->len++;
-    return 0;
-}
-
-yajl_gen_status
-gen_json_map_string_bool (void *ctx, const json_map_string_bool * map,
-			  const struct parser_context *ptx,
-			  parser_error * err)
+gen_json_map_string_int64 (void *ctx, const json_map_string_int64 *map, const struct parser_context *ptx,
+                           parser_error *err)
 {
   yajl_gen_status stat = yajl_gen_status_ok;
   yajl_gen g = (yajl_gen) ctx;
   size_t len = 0, i = 0;
   if (map != NULL)
     len = map->len;
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
+    yajl_gen_config (g, yajl_gen_beautify, 0);
+  stat = yajl_gen_map_open ((yajl_gen) g);
+  if (yajl_gen_status_ok != stat)
+    GEN_SET_ERROR_AND_RETURN (stat, err);
+
+  for (i = 0; i < len; i++)
+    {
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->keys[i]), strlen (map->keys[i]));
+      if (yajl_gen_status_ok != stat)
+        GEN_SET_ERROR_AND_RETURN (stat, err);
+      stat = map_int (g, map->values[i]);
+      if (yajl_gen_status_ok != stat)
+        GEN_SET_ERROR_AND_RETURN (stat, err);
+    }
+
+  stat = yajl_gen_map_close ((yajl_gen) g);
+  if (yajl_gen_status_ok != stat)
+    GEN_SET_ERROR_AND_RETURN (stat, err);
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
+    yajl_gen_config (g, yajl_gen_beautify, 1);
+  return yajl_gen_status_ok;
+}
+
+void
+free_json_map_string_int64 (json_map_string_int64 *map)
+{
+  if (map != NULL)
+    {
+      size_t i;
+      for (i = 0; i < map->len; i++)
+        {
+          free (map->keys[i]);
+          map->keys[i] = NULL;
+        }
+      free (map->keys);
+      map->keys = NULL;
+      free (map->values);
+      map->values = NULL;
+      free (map);
+    }
+}
+
+define_cleaner_function (json_map_string_int64 *, free_json_map_string_int64)
+
+    json_map_string_int64 *make_json_map_string_int64 (yajl_val src, const struct parser_context *ctx,
+                                                       parser_error *err)
+{
+  __auto_cleanup (free_json_map_string_int64) json_map_string_int64 *ret = NULL;
+
+  (void) ctx; /* Silence compiler warning.  */
+
+  if (src != NULL && YAJL_GET_OBJECT (src) != NULL)
+    {
+      size_t i;
+      size_t len = YAJL_GET_OBJECT (src)->len;
+      ret = safe_malloc (sizeof (*ret));
+      ret->len = len;
+      ret->keys = safe_malloc ((len + 1) * sizeof (char *));
+      ret->values = safe_malloc ((len + 1) * sizeof (int64_t));
+      for (i = 0; i < len; i++)
+        {
+          const char *srckey = YAJL_GET_OBJECT (src)->keys[i];
+          yajl_val srcval = YAJL_GET_OBJECT (src)->values[i];
+          ret->keys[i] = safe_strdup (srckey ? srckey : "");
+
+          if (srcval != NULL)
+            {
+              int64_t invalid;
+              if (! YAJL_IS_NUMBER (srcval))
+                {
+                  if (*err == NULL && asprintf (err, "Invalid value with type 'int' for key '%s'", srckey) < 0)
+                    {
+                      *(err) = safe_strdup ("error allocating memory");
+                    }
+                  return NULL;
+                }
+              invalid = common_safe_int64 (YAJL_GET_NUMBER (srcval), &(ret->values[i]));
+              if (invalid)
+                {
+                  if (*err == NULL
+                      && asprintf (err, "Invalid value with type 'int' for key '%s': %s", srckey, strerror (-invalid))
+                             < 0)
+                    {
+                      *(err) = safe_strdup ("error allocating memory");
+                    }
+                  return NULL;
+                }
+            }
+        }
+    }
+  return move_ptr (ret);
+}
+int
+append_json_map_string_int64 (json_map_string_int64 *map, const char *key, int64_t val)
+{
+  size_t len;
+  char **keys = NULL;
+  int64_t *vals = NULL;
+
+  if (map == NULL)
+    return -1;
+
+  if ((SIZE_MAX / sizeof (char *) - 1) < map->len || (SIZE_MAX / sizeof (int) - 1) < map->len)
+    return -1;
+
+  len = map->len + 1;
+  keys = safe_malloc (len * sizeof (char *));
+  vals = safe_malloc (len * sizeof (int64_t));
+
+  if (map->len)
+    {
+      (void) memcpy (keys, map->keys, map->len * sizeof (char *));
+      (void) memcpy (vals, map->values, map->len * sizeof (int64_t));
+    }
+  free (map->keys);
+  map->keys = keys;
+  free (map->values);
+  map->values = vals;
+  map->keys[map->len] = safe_strdup (key ? key : "");
+  map->values[map->len] = val;
+
+  map->len++;
+  return 0;
+}
+
+yajl_gen_status
+gen_json_map_string_bool (void *ctx, const json_map_string_bool *map, const struct parser_context *ptx,
+                          parser_error *err)
+{
+  yajl_gen_status stat = yajl_gen_status_ok;
+  yajl_gen g = (yajl_gen) ctx;
+  size_t len = 0, i = 0;
+  if (map != NULL)
+    len = map->len;
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 0);
   stat = yajl_gen_map_open ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
     GEN_SET_ERROR_AND_RETURN (stat, err);
   for (i = 0; i < len; i++)
     {
-      stat =
-	yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->keys[i]),
-			 strlen (map->keys[i]));
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->keys[i]), strlen (map->keys[i]));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
       stat = yajl_gen_bool ((yajl_gen) g, (int) (map->values[i]));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
   stat = yajl_gen_map_close ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
     GEN_SET_ERROR_AND_RETURN (stat, err);
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 1);
   return yajl_gen_status_ok;
 }
 
 void
-free_json_map_string_bool (json_map_string_bool * map)
+free_json_map_string_bool (json_map_string_bool *map)
 {
   if (map != NULL)
     {
       size_t i;
       for (i = 0; i < map->len; i++)
-	{
-	  free (map->keys[i]);
-	  map->keys[i] = NULL;
-	  // No need to free value for type bool
-	}
+        {
+          free (map->keys[i]);
+          map->keys[i] = NULL;
+          // No need to free value for type bool
+        }
       free (map->keys);
       map->keys = NULL;
       free (map->values);
@@ -1354,15 +1315,13 @@ free_json_map_string_bool (json_map_string_bool * map)
 
 define_cleaner_function (json_map_string_bool *, free_json_map_string_bool)
 
-json_map_string_bool *
-make_json_map_string_bool (yajl_val src, const struct parser_context *ctx,
-			   parser_error * err)
+    json_map_string_bool *make_json_map_string_bool (yajl_val src, const struct parser_context *ctx, parser_error *err)
 {
-  __auto_cleanup(free_json_map_string_bool) json_map_string_bool *ret = NULL;
+  __auto_cleanup (free_json_map_string_bool) json_map_string_bool *ret = NULL;
   size_t i;
   size_t len;
 
-  (void) ctx;			/* Silence compiler warning.  */
+  (void) ctx; /* Silence compiler warning.  */
 
   len = YAJL_GET_OBJECT_NO_CHECK (src)->len;
 
@@ -1407,8 +1366,7 @@ make_json_map_string_bool (yajl_val src, const struct parser_context *ctx,
             ret->values[i] = false;
           else
             {
-              if (*err == NULL && asprintf (err,
-                   "Invalid value with type 'bool' for key '%s'", srckey) < 0)
+              if (*err == NULL && asprintf (err, "Invalid value with type 'bool' for key '%s'", srckey) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -1420,8 +1378,7 @@ make_json_map_string_bool (yajl_val src, const struct parser_context *ctx,
 }
 
 int
-append_json_map_string_bool (json_map_string_bool * map, const char *key,
-			     bool val)
+append_json_map_string_bool (json_map_string_bool *map, const char *key, bool val)
 {
   size_t len;
   __auto_free char **keys = NULL;
@@ -1431,8 +1388,7 @@ append_json_map_string_bool (json_map_string_bool * map, const char *key,
   if (map == NULL)
     return -1;
 
-  if ((SIZE_MAX / sizeof (char *) - 1) < map->len
-      || (SIZE_MAX / sizeof (bool) - 1) < map->len)
+  if ((SIZE_MAX / sizeof (char *) - 1) < map->len || (SIZE_MAX / sizeof (bool) - 1) < map->len)
     return -1;
 
   len = map->len + 1;
@@ -1471,9 +1427,8 @@ append_json_map_string_bool (json_map_string_bool * map, const char *key,
 }
 
 yajl_gen_status
-gen_json_map_string_string (void *ctx, const json_map_string_string * map,
-			    const struct parser_context *ptx,
-			    parser_error * err)
+gen_json_map_string_string (void *ctx, const json_map_string_string *map, const struct parser_context *ptx,
+                            parser_error *err)
 {
   yajl_gen_status stat = yajl_gen_status_ok;
   yajl_gen g = (yajl_gen) ctx;
@@ -1481,7 +1436,7 @@ gen_json_map_string_string (void *ctx, const json_map_string_string * map,
   if (map != NULL)
     len = map->len;
 
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 0);
 
   stat = yajl_gen_map_open ((yajl_gen) g);
@@ -1490,40 +1445,35 @@ gen_json_map_string_string (void *ctx, const json_map_string_string * map,
 
   for (i = 0; i < len; i++)
     {
-      stat =
-	yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->keys[i]),
-			 strlen (map->keys[i]));
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->keys[i]), strlen (map->keys[i]));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
-      stat =
-	yajl_gen_string ((yajl_gen) g,
-			 (const unsigned char *) (map->values[i]),
-			 strlen (map->values[i]));
+        GEN_SET_ERROR_AND_RETURN (stat, err);
+      stat = yajl_gen_string ((yajl_gen) g, (const unsigned char *) (map->values[i]), strlen (map->values[i]));
       if (yajl_gen_status_ok != stat)
-	GEN_SET_ERROR_AND_RETURN (stat, err);
+        GEN_SET_ERROR_AND_RETURN (stat, err);
     }
 
   stat = yajl_gen_map_close ((yajl_gen) g);
   if (yajl_gen_status_ok != stat)
     GEN_SET_ERROR_AND_RETURN (stat, err);
-  if (!len && !(ptx->options & OPT_GEN_SIMPLIFY))
+  if (! len && ! (ptx->options & OPT_GEN_SIMPLIFY))
     yajl_gen_config (g, yajl_gen_beautify, 1);
   return yajl_gen_status_ok;
 }
 
 void
-free_json_map_string_string (json_map_string_string * map)
+free_json_map_string_string (json_map_string_string *map)
 {
   if (map != NULL)
     {
       size_t i;
       for (i = 0; i < map->len; i++)
-	{
-	  free (map->keys[i]);
-	  map->keys[i] = NULL;
-	  free (map->values[i]);
-	  map->values[i] = NULL;
-	}
+        {
+          free (map->keys[i]);
+          map->keys[i] = NULL;
+          free (map->values[i]);
+          map->values[i] = NULL;
+        }
       free (map->keys);
       map->keys = NULL;
       free (map->values);
@@ -1534,15 +1484,14 @@ free_json_map_string_string (json_map_string_string * map)
 
 define_cleaner_function (json_map_string_string *, free_json_map_string_string)
 
-json_map_string_string *
-make_json_map_string_string (yajl_val src, const struct parser_context *ctx,
-			     parser_error * err)
+    json_map_string_string *make_json_map_string_string (yajl_val src, const struct parser_context *ctx,
+                                                         parser_error *err)
 {
-  __auto_cleanup(free_json_map_string_string) json_map_string_string *ret = NULL;
+  __auto_cleanup (free_json_map_string_string) json_map_string_string *ret = NULL;
   size_t i;
   size_t len;
 
-  (void) ctx;			/* Silence compiler warning.  */
+  (void) ctx; /* Silence compiler warning.  */
   if (src == NULL || YAJL_GET_OBJECT (src) == NULL)
     return NULL;
 
@@ -1587,10 +1536,9 @@ make_json_map_string_string (yajl_val src, const struct parser_context *ctx,
       if (srcval != NULL)
         {
           char *str;
-          if (!YAJL_IS_STRING (srcval))
+          if (! YAJL_IS_STRING (srcval))
             {
-              if (*err == NULL && asprintf (err,
-                   "Invalid value with type 'string' for key '%s'", srckey) < 0)
+              if (*err == NULL && asprintf (err, "Invalid value with type 'string' for key '%s'", srckey) < 0)
                 {
                   *err = strdup ("error allocating memory");
                 }
@@ -1610,8 +1558,7 @@ make_json_map_string_string (yajl_val src, const struct parser_context *ctx,
 }
 
 int
-append_json_map_string_string (json_map_string_string * map, const char *key,
-			       const char *val)
+append_json_map_string_string (json_map_string_string *map, const char *key, const char *val)
 {
   size_t len, i;
   __auto_free char **keys = NULL;
@@ -1625,14 +1572,14 @@ append_json_map_string_string (json_map_string_string * map, const char *key,
   for (i = 0; i < map->len; i++)
     {
       if (strcmp (map->keys[i], key) == 0)
-	{
+        {
           char *v = strdup (val ? val : "");
           if (v == NULL)
             return -1;
-	  free (map->values[i]);
-	  map->values[i] = v;
-	  return 0;
-	}
+          free (map->values[i]);
+          map->values[i] = v;
+          return 0;
+        }
     }
 
   if ((SIZE_MAX / sizeof (char *) - 1) < map->len)
@@ -1670,9 +1617,9 @@ append_json_map_string_string (json_map_string_string * map, const char *key,
 }
 
 static void
-cleanup_yajl_gen(yajl_gen g)
+cleanup_yajl_gen (yajl_gen g)
 {
-  if (!g)
+  if (! g)
     return;
   yajl_gen_clear (g);
   yajl_gen_free (g);
@@ -1680,11 +1627,9 @@ cleanup_yajl_gen(yajl_gen g)
 
 define_cleaner_function (yajl_gen, cleanup_yajl_gen)
 
-char *
-json_marshal_string (const char *str, size_t length,
-		     const struct parser_context *ctx, parser_error * err)
+    char *json_marshal_string (const char *str, size_t length, const struct parser_context *ctx, parser_error *err)
 {
-  __auto_cleanup(cleanup_yajl_gen) yajl_gen g = NULL;
+  __auto_cleanup (cleanup_yajl_gen) yajl_gen g = NULL;
   struct parser_context tmp_ctx = { 0 };
   const unsigned char *gen_buf = NULL;
   char *json_buf = NULL;
@@ -1698,7 +1643,7 @@ json_marshal_string (const char *str, size_t length,
   if (ctx == NULL)
     ctx = (const struct parser_context *) (&tmp_ctx);
 
-  if (!json_gen_init (&g, ctx))
+  if (! json_gen_init (&g, ctx))
     {
       *err = strdup ("Json_gen init failed");
       return json_buf;
@@ -1707,7 +1652,7 @@ json_marshal_string (const char *str, size_t length,
   if (yajl_gen_status_ok != stat)
     {
       if (asprintf (err, "error generating json, errcode: %d", (int) stat) < 0)
-          *err = strdup ("error allocating memory");
+        *err = strdup ("error allocating memory");
       return json_buf;
     }
   yajl_gen_get_buf (g, &gen_buf, &gen_len);
@@ -1729,4 +1674,3 @@ json_marshal_string (const char *str, size_t length,
 
   return json_buf;
 }
-        

--- a/src/json_common.c
+++ b/src/json_common.c
@@ -1,47 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# libocispec - a C library for parsing OCI spec files.
-#
-# Copyright (C) Huawei Technologies., Ltd. 2018-2020.
-# Copyright (C) 2017, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
-#
-# libocispec is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
-# (at your option) any later version.
-#
-# libocispec is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
-
-# As a special exception, you may create a larger work that contains
-# part or all of the libocispec parser skeleton and distribute that work
-# under terms of your choice, so long as that work isn't itself a
-# parser generator using the skeleton or a modified version thereof
-# as a parser skeleton.  Alternatively, if you modify or redistribute
-# the parser skeleton itself, you may (at your option) remove this
-# special exception, which will cause the skeleton and the resulting
-# libocispec output files to be licensed under the GNU General Public
-# License without this special exception.
-
-import os
-import fcntl
-
-"""
-Description: json common c code
-Interface: None
-History: 2019-06-18
-Purpose: defined the common tool function for parse json
-Defined the CODE global variable to hold the c code
-"""
-def generate_json_common_c(out):
-    with open(os.path.join(out, 'json_common.c'), "w") as source_file:
-        fcntl.flock(source_file, fcntl.LOCK_EX)
-        source_file.write("""// Auto generated file. Do not edit!
 # define _GNU_SOURCE
 # include <stdio.h>
 # include <string.h>
@@ -253,7 +209,7 @@ common_safe_double (const char *numstr, double *converted)
     return -errno;
 
 
-  if (err_str == NULL || err_str == numstr || *err_str != '\\0')
+  if (err_str == NULL || err_str == numstr || *err_str != '\0')
     return -EINVAL;
 
   *converted = d;
@@ -274,7 +230,7 @@ common_safe_uint8 (const char *numstr, uint8_t * converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   if (uli > UINT8_MAX)
@@ -298,7 +254,7 @@ common_safe_uint16 (const char *numstr, uint16_t * converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   if (uli > UINT16_MAX)
@@ -322,7 +278,7 @@ common_safe_uint32 (const char *numstr, uint32_t * converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   if (ull > UINT32_MAX)
@@ -346,7 +302,7 @@ common_safe_uint64 (const char *numstr, uint64_t * converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   *converted = (uint64_t) ull;
@@ -367,7 +323,7 @@ common_safe_uint (const char *numstr, unsigned int *converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   if (ull > UINT_MAX)
@@ -393,7 +349,7 @@ common_safe_int8 (const char *numstr, int8_t * converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   if (li > INT8_MAX || li < INT8_MIN)
@@ -417,7 +373,7 @@ common_safe_int16 (const char *numstr, int16_t * converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   if (li > INT16_MAX || li < INT16_MIN)
@@ -441,7 +397,7 @@ common_safe_int32 (const char *numstr, int32_t * converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   if (lli > INT32_MAX || lli < INT32_MIN)
@@ -466,7 +422,7 @@ common_safe_int64 (const char *numstr, int64_t * converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   *converted = (int64_t) lli;
@@ -487,7 +443,7 @@ common_safe_int (const char *numstr, int *converted)
   if (errno > 0)
     return -errno;
 
-  if (err == NULL || err == numstr || *err != '\\0')
+  if (err == NULL || err == numstr || *err != '\0')
     return -EINVAL;
 
   if (lli > INT_MAX || lli < INT_MIN)
@@ -1769,9 +1725,8 @@ json_marshal_string (const char *str, size_t length,
     }
 
   (void) memcpy (json_buf, gen_buf, gen_len);
-  json_buf[gen_len] = '\\0';
+  json_buf[gen_len] = '\0';
 
   return json_buf;
 }
-        """)
-        fcntl.flock(source_file, fcntl.LOCK_UN)
+        

--- a/src/json_common.h
+++ b/src/json_common.h
@@ -1,61 +1,66 @@
-# ifndef _JSON_COMMON_H
-# define _JSON_COMMON_H
+#ifndef _JSON_COMMON_H
+#define _JSON_COMMON_H
 
-# include <stdlib.h>
-# include <stdbool.h>
-# include <stdio.h>
-# include <string.h>
-# include <stdint.h>
-# include <yajl/yajl_tree.h>
-# include <yajl/yajl_gen.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <yajl/yajl_tree.h>
+#include <yajl/yajl_gen.h>
 
-# ifdef __cplusplus
+#ifdef __cplusplus
 extern "C" {
-# endif
+#endif
 
-# undef linux
+#undef linux
 
 // options to report error if there is unknown key found in json
-# define OPT_PARSE_STRICT 0x01
+#define OPT_PARSE_STRICT 0x01
 // options to generate all key and value
-# define OPT_GEN_KEY_VALUE 0x02
+#define OPT_GEN_KEY_VALUE 0x02
 // options to generate simplify(no indent) json string
-# define OPT_GEN_SIMPLIFY 0x04
+#define OPT_GEN_SIMPLIFY 0x04
 // options to keep all keys and values, even do not known
-# define OPT_PARSE_FULLKEY 0x08
+#define OPT_PARSE_FULLKEY 0x08
 // options not to validate utf8 data
-# define OPT_GEN_NO_VALIDATE_UTF8 0x10
+#define OPT_GEN_NO_VALIDATE_UTF8 0x10
 
-#define define_cleaner_function(type, cleaner)           \
-        static inline void cleaner##_function(type *ptr) \
-        {                                                \
-                if (*ptr)                                \
-                        cleaner(*ptr);                   \
-        }
+#define define_cleaner_function(type, cleaner)      \
+  static inline void cleaner##_function (type *ptr) \
+  {                                                 \
+    if (*ptr)                                       \
+      cleaner (*ptr);                               \
+  }
 
-#define __auto_cleanup(cleaner) __attribute__((__cleanup__(cleaner##_function)))
+#define __auto_cleanup(cleaner) __attribute__ ((__cleanup__ (cleaner##_function)))
 
-static inline void ptr_free_function(void *p) {
-    free(*(void**)p);
+static inline void
+ptr_free_function (void *p)
+{
+  free (*(void **) p);
 }
 
-#define __auto_free __auto_cleanup(ptr_free)
+#define __auto_free __auto_cleanup (ptr_free)
 
-#define move_ptr(ptr)                                 \
-        ({                                            \
-                typeof(ptr) moved_ptr = (ptr);        \
-                (ptr) = NULL;                         \
-                moved_ptr;                            \
-        })
+#define move_ptr(ptr)               \
+  ({                                \
+    typeof (ptr) moved_ptr = (ptr); \
+    (ptr) = NULL;                   \
+    moved_ptr;                      \
+  })
 
-# define GEN_SET_ERROR_AND_RETURN(stat, err) { \
-    if (*(err) == NULL) {\
-        if (asprintf (err, "%s: %s: %d: error generating json, errcode: %u", __FILE__, __func__, __LINE__, stat) < 0) { \
-            *(err) = strdup ("error allocating memory"); \
-        } \
-    }\
-    return stat; \
-}
+#define GEN_SET_ERROR_AND_RETURN(stat, err)                                                                           \
+  {                                                                                                                   \
+    if (*(err) == NULL)                                                                                               \
+      {                                                                                                               \
+        if (asprintf (err, "%s: %s: %d: error generating json, errcode: %u", __FILE__, __func__, __LINE__, stat) < 0) \
+          {                                                                                                           \
+            *(err) = strdup ("error allocating memory");                                                              \
+          }                                                                                                           \
+      }                                                                                                               \
+    return stat;                                                                                                      \
+  }
 
 typedef char *parser_error;
 
@@ -71,7 +76,7 @@ yajl_gen_status map_uint (void *ctx, long long unsigned int num);
 
 yajl_gen_status map_int (void *ctx, long long int num);
 
-bool json_gen_init (yajl_gen * g, const struct parser_context *ctx);
+bool json_gen_init (yajl_gen *g, const struct parser_context *ctx);
 
 yajl_val get_val (yajl_val tree, const char *name, yajl_type type);
 
@@ -81,23 +86,23 @@ void *safe_malloc (size_t size);
 
 int common_safe_double (const char *numstr, double *converted);
 
-int common_safe_uint8 (const char *numstr, uint8_t * converted);
+int common_safe_uint8 (const char *numstr, uint8_t *converted);
 
-int common_safe_uint16 (const char *numstr, uint16_t * converted);
+int common_safe_uint16 (const char *numstr, uint16_t *converted);
 
-int common_safe_uint32 (const char *numstr, uint32_t * converted);
+int common_safe_uint32 (const char *numstr, uint32_t *converted);
 
-int common_safe_uint64 (const char *numstr, uint64_t * converted);
+int common_safe_uint64 (const char *numstr, uint64_t *converted);
 
 int common_safe_uint (const char *numstr, unsigned int *converted);
 
-int common_safe_int8 (const char *numstr, int8_t * converted);
+int common_safe_int8 (const char *numstr, int8_t *converted);
 
-int common_safe_int16 (const char *numstr, int16_t * converted);
+int common_safe_int16 (const char *numstr, int16_t *converted);
 
-int common_safe_int32 (const char *numstr, int32_t * converted);
+int common_safe_int32 (const char *numstr, int32_t *converted);
 
-int common_safe_int64 (const char *numstr, int64_t * converted);
+int common_safe_int64 (const char *numstr, int64_t *converted);
 
 int common_safe_int (const char *numstr, int *converted);
 
@@ -108,17 +113,14 @@ typedef struct
   size_t len;
 } json_map_int_int;
 
-void free_json_map_int_int (json_map_int_int * map);
+void free_json_map_int_int (json_map_int_int *map);
 
-json_map_int_int *make_json_map_int_int (yajl_val src,
-					 const struct parser_context *ctx,
-					 parser_error * err);
+json_map_int_int *make_json_map_int_int (yajl_val src, const struct parser_context *ctx, parser_error *err);
 
-yajl_gen_status gen_json_map_int_int (void *ctx, const json_map_int_int * map,
-				      const struct parser_context *ptx,
-				      parser_error * err);
+yajl_gen_status gen_json_map_int_int (void *ctx, const json_map_int_int *map, const struct parser_context *ptx,
+                                      parser_error *err);
 
-int append_json_map_int_int (json_map_int_int * map, int key, int val);
+int append_json_map_int_int (json_map_int_int *map, int key, int val);
 
 typedef struct
 {
@@ -127,18 +129,14 @@ typedef struct
   size_t len;
 } json_map_int_bool;
 
-void free_json_map_int_bool (json_map_int_bool * map);
+void free_json_map_int_bool (json_map_int_bool *map);
 
-json_map_int_bool *make_json_map_int_bool (yajl_val src,
-					   const struct parser_context *ctx,
-					   parser_error * err);
+json_map_int_bool *make_json_map_int_bool (yajl_val src, const struct parser_context *ctx, parser_error *err);
 
-yajl_gen_status gen_json_map_int_bool (void *ctx,
-				       const json_map_int_bool * map,
-				       const struct parser_context *ptx,
-				       parser_error * err);
+yajl_gen_status gen_json_map_int_bool (void *ctx, const json_map_int_bool *map, const struct parser_context *ptx,
+                                       parser_error *err);
 
-int append_json_map_int_bool (json_map_int_bool * map, int key, bool val);
+int append_json_map_int_bool (json_map_int_bool *map, int key, bool val);
 
 typedef struct
 {
@@ -147,19 +145,14 @@ typedef struct
   size_t len;
 } json_map_int_string;
 
-void free_json_map_int_string (json_map_int_string * map);
+void free_json_map_int_string (json_map_int_string *map);
 
-json_map_int_string *make_json_map_int_string (yajl_val src,
-					       const struct parser_context
-					       *ctx, parser_error * err);
+json_map_int_string *make_json_map_int_string (yajl_val src, const struct parser_context *ctx, parser_error *err);
 
-yajl_gen_status gen_json_map_int_string (void *ctx,
-					 const json_map_int_string * map,
-					 const struct parser_context *ptx,
-					 parser_error * err);
+yajl_gen_status gen_json_map_int_string (void *ctx, const json_map_int_string *map, const struct parser_context *ptx,
+                                         parser_error *err);
 
-int append_json_map_int_string (json_map_int_string * map, int key,
-				const char *val);
+int append_json_map_int_string (json_map_int_string *map, int key, const char *val);
 
 typedef struct
 {
@@ -168,19 +161,14 @@ typedef struct
   size_t len;
 } json_map_string_int;
 
-void free_json_map_string_int (json_map_string_int * map);
+void free_json_map_string_int (json_map_string_int *map);
 
-json_map_string_int *make_json_map_string_int (yajl_val src,
-					       const struct parser_context
-					       *ctx, parser_error * err);
+json_map_string_int *make_json_map_string_int (yajl_val src, const struct parser_context *ctx, parser_error *err);
 
-yajl_gen_status gen_json_map_string_int (void *ctx,
-					 const json_map_string_int * map,
-					 const struct parser_context *ptx,
-					 parser_error * err);
+yajl_gen_status gen_json_map_string_int (void *ctx, const json_map_string_int *map, const struct parser_context *ptx,
+                                         parser_error *err);
 
-int append_json_map_string_int (json_map_string_int * map, const char *key,
-				int val);
+int append_json_map_string_int (json_map_string_int *map, const char *key, int val);
 
 typedef struct
 {
@@ -189,40 +177,30 @@ typedef struct
   size_t len;
 } json_map_string_bool;
 
-void free_json_map_string_bool (json_map_string_bool * map);
+void free_json_map_string_bool (json_map_string_bool *map);
 
-json_map_string_bool *make_json_map_string_bool (yajl_val src,
-						 const struct parser_context
-						 *ctx, parser_error * err);
+json_map_string_bool *make_json_map_string_bool (yajl_val src, const struct parser_context *ctx, parser_error *err);
 
 typedef struct
 {
-    char **keys;
-    int64_t *values;
-    size_t len;
+  char **keys;
+  int64_t *values;
+  size_t len;
 } json_map_string_int64;
 
 void free_json_map_string_int64 (json_map_string_int64 *map);
 
-json_map_string_int64 *make_json_map_string_int64 (yajl_val src,
-                                                   const struct
-                                                   parser_context *ctx,
-                                                   parser_error *err);
+json_map_string_int64 *make_json_map_string_int64 (yajl_val src, const struct parser_context *ctx, parser_error *err);
 
-yajl_gen_status gen_json_map_string_int64 (void *ctx,
-                                           const json_map_string_int64 *map,
-                                           const struct parser_context *ptx,
-                                           parser_error *err);
+yajl_gen_status gen_json_map_string_int64 (void *ctx, const json_map_string_int64 *map,
+                                           const struct parser_context *ptx, parser_error *err);
 
 int append_json_map_string_int64 (json_map_string_int64 *map, const char *key, int64_t val);
 
-yajl_gen_status gen_json_map_string_bool (void *ctx,
-					  const json_map_string_bool * map,
-					  const struct parser_context *ptx,
-					  parser_error * err);
+yajl_gen_status gen_json_map_string_bool (void *ctx, const json_map_string_bool *map, const struct parser_context *ptx,
+                                          parser_error *err);
 
-int append_json_map_string_bool (json_map_string_bool * map, const char *key,
-				 bool val);
+int append_json_map_string_bool (json_map_string_bool *map, const char *key, bool val);
 
 typedef struct
 {
@@ -231,29 +209,19 @@ typedef struct
   size_t len;
 } json_map_string_string;
 
-void free_json_map_string_string (json_map_string_string * map);
+void free_json_map_string_string (json_map_string_string *map);
 
-json_map_string_string *make_json_map_string_string (yajl_val src,
-						     const struct
-						     parser_context *ctx,
-						     parser_error * err);
+json_map_string_string *make_json_map_string_string (yajl_val src, const struct parser_context *ctx, parser_error *err);
 
-yajl_gen_status gen_json_map_string_string (void *ctx,
-					    const json_map_string_string *
-					    map,
-					    const struct parser_context *ptx,
-					    parser_error * err);
+yajl_gen_status gen_json_map_string_string (void *ctx, const json_map_string_string *map,
+                                            const struct parser_context *ptx, parser_error *err);
 
-int append_json_map_string_string (json_map_string_string * map,
-				   const char *key, const char *val);
+int append_json_map_string_string (json_map_string_string *map, const char *key, const char *val);
 
-char *json_marshal_string (const char *str, size_t length,
-			   const struct parser_context *ctx,
-			   parser_error * err);
+char *json_marshal_string (const char *str, size_t length, const struct parser_context *ctx, parser_error *err);
 
-# ifdef __cplusplus
+#ifdef __cplusplus
 }
-# endif
+#endif
 
-# endif
-        
+#endif

--- a/src/json_common.h
+++ b/src/json_common.h
@@ -1,47 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# libocispec - a C library for parsing OCI spec files.
-#
-# Copyright (C) Huawei Technologies., Ltd. 2018-2020.
-# Copyright (C) 2017, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
-#
-# libocispec is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
-# (at your option) any later version.
-#
-# libocispec is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
-
-# As a special exception, you may create a larger work that contains
-# part or all of the libocispec parser skeleton and distribute that work
-# under terms of your choice, so long as that work isn't itself a
-# parser generator using the skeleton or a modified version thereof
-# as a parser skeleton.  Alternatively, if you modify or redistribute
-# the parser skeleton itself, you may (at your option) remove this
-# special exception, which will cause the skeleton and the resulting
-# libocispec output files to be licensed under the GNU General Public
-# License without this special exception.
-
-import os
-import fcntl
-
-"""
-Description: json common c code
-Interface: None
-History: 2019-06-18
-Purpose: defined the common tool function for parse json
-Defined the CODE global variable to hold the c code
-"""
-def generate_json_common_h(out):
-    with open(os.path.join(out, 'json_common.h'), "w") as header_file:
-        fcntl.flock(header_file, fcntl.LOCK_EX)
-        header_file.write("""// Auto generated file. Do not edit!
 # ifndef _JSON_COMMON_H
 # define _JSON_COMMON_H
 
@@ -70,11 +26,11 @@ extern "C" {
 // options not to validate utf8 data
 # define OPT_GEN_NO_VALIDATE_UTF8 0x10
 
-#define define_cleaner_function(type, cleaner)           \\
-        static inline void cleaner##_function(type *ptr) \\
-        {                                                \\
-                if (*ptr)                                \\
-                        cleaner(*ptr);                   \\
+#define define_cleaner_function(type, cleaner)           \
+        static inline void cleaner##_function(type *ptr) \
+        {                                                \
+                if (*ptr)                                \
+                        cleaner(*ptr);                   \
         }
 
 #define __auto_cleanup(cleaner) __attribute__((__cleanup__(cleaner##_function)))
@@ -85,20 +41,20 @@ static inline void ptr_free_function(void *p) {
 
 #define __auto_free __auto_cleanup(ptr_free)
 
-#define move_ptr(ptr)                                 \\
-        ({                                            \\
-                typeof(ptr) moved_ptr = (ptr);        \\
-                (ptr) = NULL;                         \\
-                moved_ptr;                            \\
+#define move_ptr(ptr)                                 \
+        ({                                            \
+                typeof(ptr) moved_ptr = (ptr);        \
+                (ptr) = NULL;                         \
+                moved_ptr;                            \
         })
 
-# define GEN_SET_ERROR_AND_RETURN(stat, err) { \\
-    if (*(err) == NULL) {\\
-        if (asprintf (err, "%s: %s: %d: error generating json, errcode: %u", __FILE__, __func__, __LINE__, stat) < 0) { \\
-            *(err) = strdup ("error allocating memory"); \\
-        } \\
-    }\\
-    return stat; \\
+# define GEN_SET_ERROR_AND_RETURN(stat, err) { \
+    if (*(err) == NULL) {\
+        if (asprintf (err, "%s: %s: %d: error generating json, errcode: %u", __FILE__, __func__, __LINE__, stat) < 0) { \
+            *(err) = strdup ("error allocating memory"); \
+        } \
+    }\
+    return stat; \
 }
 
 typedef char *parser_error;
@@ -300,5 +256,4 @@ char *json_marshal_string (const char *str, size_t length,
 # endif
 
 # endif
-        """)
-        fcntl.flock(header_file, fcntl.LOCK_UN)
+        


### PR DESCRIPTION
increase granularity for the make rules and solve a problem with
multiple targets writing to the same output files.

Closes: https://github.com/containers/libocispec/issues/70

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>