### PR TITLE
Rust bindings: Update serializer to indent json before writing to file & update docs to use `main` branch for old cargo users. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,15 @@ Generating an OCI configuration json string is also easy as:
 libocispec supports rust bindings as well. You can use it directly by adding it as dependency to `Cargo.toml` or generate fresh types using `make generate-rust`
 ```toml
 [dependencies]
-libocispec = { git = "https://github.com/containers/libocispec", branch = "master" }
+libocispec = { git = "https://github.com/containers/libocispec" }
+```
+for Cargo version older than `0.51.0` specify branch explicitly
+```toml
+[dependencies]
+libocispec = { git = "https://github.com/containers/libocispec", branch = "main" }
 ```
 Example usage
-```rs
+```rust
 extern crate libocispec;
 use libocispec::runtime;
 use libocispec::image;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -48,7 +48,7 @@ impl From<serde_json::Error> for SerializeError {
 
 pub fn serialize<T: serde::Serialize>(obj: &T, path: &str) -> Result<(), SerializeError> {
     let mut file = File::create(path)?;
-    Ok(serde_json::to_writer(&mut file, &obj)?)
+    Ok(serde_json::to_writer_pretty(&mut file, &obj)?)
 }
 
 pub fn deserialize<T>(path: &str) -> Result<T, SerializeError> 


### PR DESCRIPTION
**Update serializer to indent json before writing to file**
`Reason:`  As of now libocispec rust binding's `Spec::save` is dumping all the json in a single line with no indentation at all. This PR fixes that.

**Update docs : Encourage old cargo users to point libocispec dependency to `main` insead of `master`.**
`Reason:`
 Cargo version older then `0.51.0` would fail even for 
```bash
libocispec = { git = "https://github.com/containers/libocispec" }
```
with error 
``` bash
Caused by:
  failed to load source for dependency `libocispec`

Caused by:
  Unable to update https://github.com/containers/libocispec

Caused by:
  failed to find branch `master`

Caused by:
  cannot locate remote-tracking branch 'origin/master'; class=Reference (4); code=NotFound (-3)
  ```
