### PR TITLE
git: ignore newly added test binary (#105)  to prevent untracked changes in crun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ tests/.deps/
 tests/.dirstamp
 tests/test-1
 tests/test-10
+tests/test-11
 tests/test-2
 tests/test-3
 tests/test-4


### PR DESCRIPTION
Ignore newly added test in https://github.com/containers/libocispec/pull/105
since it generates a new binary called `test-11` which is being reflected as
untracked changes in fresh crun build from `main`.

Issue
* Pull and build a fresh crun
* Run `git status`

```console
$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)
	modified:   libocispec (untracked content)  <-------- Here
```