### PR TITLE
rust, runtime: sync and add `domainname` to spec from upstream.

### DIFF
--- a/diff
+++ b/diff
@@ -1,0 +1,15 @@
+diff --git a/src/runtime/mod.rs b/src/runtime/mod.rs
+index f5c9d39..7236df8 100644
+--- a/src/runtime/mod.rs
++++ b/src/runtime/mod.rs
+@@ -20,6 +20,9 @@ pub struct Spec {
+     #[serde(rename = "annotations")]
+     pub annotations: Option<HashMap<String, Option<serde_json::Value>>>,
+ 
++    #[serde(rename = "domainname")]
++    pub domainname: Option<String>,
++
+     #[serde(rename = "hooks")]
+     pub hooks: Option<Hooks>,
+ 
+

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -20,6 +20,9 @@ pub struct Spec {
     #[serde(rename = "annotations")]
     pub annotations: Option<HashMap<String, Option<serde_json::Value>>>,
 
+    #[serde(rename = "domainname")]
+    pub domainname: Option<String>,
+
     #[serde(rename = "hooks")]
     pub hooks: Option<Hooks>,
 


### PR DESCRIPTION
Sync from upstream runtime-spec which adds new field `domainname`
to the spec.