### PR TITLE
Make libocispec installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ m4/*
 Makefile
 Makefile.in
 *.o
+ocispec.pc
 src/basic_test_double_array.c
 src/basic_test_double_array.h
 src/basic_test_double_array_item.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,8 +11,14 @@ CLEANFILES = $(man_MANS) src/runtime_spec_stamp src/image_spec_stamp src/image_m
 
 GITIGNOREFILES = build-aux/ gtk-doc.make config.h.in aclocal.m4
 
+
+if ENABLE_LIBOCISPEC_INSTALL
+lib_LTLIBRARIES = libocispec.la
+lib_LIBRARIES = libocispec.a
+else
 noinst_LTLIBRARIES = libocispec.la
 noinst_LIBRARIES = libocispec.a
+endif
 
 SOURCE_FILES = \
 	src/image_spec_schema_config_schema.c \
@@ -45,6 +51,13 @@ SOURCE_FILES = \
 	src/basic_test_top_double_array_string.c
 
 HEADER_FILES = $(SOURCE_FILES:.c=.h)
+
+if ENABLE_LIBOCISPEC_INSTALL
+ocispec_includedir = $(includedir)
+ocispec_include_HEADERS = $(HEADER_FILES) \
+                          src/json_common.h \
+                          src/read-file.h
+endif
 
 src/runtime_spec_stamp: src/json_common.h src/json_common.c
 	$(PYTHON) $(srcdir)/src/generate.py --gen-ref --root=${srcdir} --out=${builddir}/src ${srcdir}/runtime-spec/schema
@@ -146,6 +159,11 @@ libocispec_a_SOURCES =
 
 libocispec.a: libocispec.la $(BUILT_SOURCES) src/runtime_spec_stamp src/image_spec_stamp src/image_manifest_stamp src/basic-test_stamp
 	$(LIBTOOL) --mode=link $(GCC) libocispec.la -o libocispec.a
+
+if ENABLE_LIBOCISPEC_INSTALL
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = ocispec.pc
+endif
 
 tests_test_1_SOURCES = tests/test-1.c
 tests_test_1_LDADD = $(TESTS_LDADD)

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,18 @@ esac],[embedded_yajl=false])
 AM_CONDITIONAL([HAVE_EMBEDDED_YAJL], [test x"$embedded_yajl" = xtrue])
 AM_COND_IF([HAVE_EMBEDDED_YAJL], [], [PKG_CHECK_MODULES([YAJL], [yajl >= 2.1.0])])
 
+# Optionally install the library.
+AC_ARG_ENABLE(libocispec-install,
+AS_HELP_STRING([--enable-libocispec-install], [Enable libocispec installation]),
+[
+case "${enableval}" in
+  yes) libocispec_install=true ;;
+  no)  libocispec_install=false ;;
+  *) AC_MSG_ERROR(bad value ${enableval} for --enable-libocispec-install) ;;
+esac],[libocispec_install=false])
+
+AM_CONDITIONAL([ENABLE_LIBOCISPEC_INSTALL], [test x"$libocispec_install" = xtrue])
+
 AC_ARG_VAR(OCI_RUNTIME_EXTENSIONS, [extensions for the OCI runtime parser])
 AC_ARG_VAR(OCI_IMAGE_EXTENSIONS, [extensions for the OCI image parser])
 AC_ARG_VAR(OCI_IMAGE_INDEX_EXTENSIONS, [extensions for the OCI image index parser])
@@ -42,5 +54,6 @@ AM_PATH_PYTHON([3])
 
 AC_CONFIG_FILES([
 Makefile
+ocispec.pc
 ])
 AC_OUTPUT

--- a/ocispec.pc.in
+++ b/ocispec.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: A library for easily parsing [OCI runtime](https://github.com/opencontainers/runtime-spec) and [OCI image](https://github.com/opencontainers/image-spec) files.
+Requires: yajl
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -locispec
+Cflags: -I${includedir}


### PR DESCRIPTION
After the changes in this PR, following the installation instructions in the [README.md](https://github.com/containers/libocispec/tree/65bdde6f82b5ce8cddc316b8f93e30bc1c35e333#installation):
```
./autogen.sh
./configure --enable-libocispec-install
make
sudo make install
```
will actually install the library, header files, and a `pkgconfig` file, as long as you call `configure` with the `--enable-libocispec-install` option. Maybe I should also update the README.md?