### PR TITLE
Fix clang17++ compilation

### DIFF
--- a/src/ocispec/generate.py
+++ b/src/ocispec/generate.py
@@ -740,7 +740,7 @@ def handle_single_file(args, srcpath, gen_ref, schemapath):
     History: 2019-06-17
     """
     if not os.path.exists(schemapath.name) or not os.path.exists(srcpath.name):
-        print('Path %s is not exist' % schemapath.name)
+        print('Path %s does not exist' % schemapath.name)
         sys.exit(1)
 
     if os.path.isdir(schemapath.name):
@@ -754,7 +754,7 @@ def handle_single_file(args, srcpath, gen_ref, schemapath):
                         reflection(schema_info, gen_ref)
                         print("\033[1;34mReflection:\033[0m\t%-60s \033[1;32mSuccess\033[0m" % (target_file))
         else:
-            # only parse files in current direcotory
+            # only parse files in current directory
             for target_file in os.listdir(schemapath.name):
                 fullpath = os.path.join(schemapath.name, target_file)
                 if fullpath.endswith(JSON_SUFFIX) and os.path.isfile(fullpath):
@@ -767,7 +767,7 @@ def handle_single_file(args, srcpath, gen_ref, schemapath):
             reflection(schema_info, gen_ref)
             print("\033[1;34mReflection:\033[0m\t%-60s \033[1;32mSuccess\033[0m" % (schemapath.name))
         else:
-            print('File %s is not ends with .json' % schemapath.name)
+            print('File %s does not end with .json' % schemapath.name)
 
 
 def handle_files(args, srcpath):
@@ -817,7 +817,7 @@ def main():
 
     root_path = os.path.realpath(args.root)
     if not os.path.exists(root_path):
-        print('Root %s is not exist' % args.root)
+        print('Root %s does not exist' % args.root)
         sys.exit(1)
 
     MyRoot.root_path = root_path

--- a/src/ocispec/helpers.py
+++ b/src/ocispec/helpers.py
@@ -28,6 +28,9 @@
 import os
 import sys
 
+cxx_reserved_keywords = ["class", "delete", "explicit", "friend", "mutable", "new",
+                          "operator", "private", "protected", "public", "throw", "try", "virtual"]
+
 def append_separator(substr):
     '''
     Description: append only '_' at last position of subStr
@@ -45,6 +48,9 @@ def conv_to_c_style(name):
     '''
     if name is None or name == "":
         return ""
+    # replace C++ reserved keywords (the generated C headers can be included in C++ applications)
+    if name in cxx_reserved_keywords:
+        name = '_' + name
     name = name.replace('.', '_').replace('-', '_').replace('/', '_')
     substr = []
     preindex = 0

--- a/src/ocispec/helpers.py
+++ b/src/ocispec/helpers.py
@@ -243,9 +243,6 @@ class CombinateName(object):
     def __repr__(self):
         return self.name
 
-    def __str__(self):
-        return self.name
-
     def append(self, leaf):
         '''
         Description: append name
@@ -283,9 +280,6 @@ class Unite(object):
                 % (self.name, self.typ, self.subtyp)
         return "name:(%s) type:(%s)" % (self.name, self.typ)
 
-    def __str__(self):
-        return self.__repr__(self)
-
 
 class FilePath(object):
     '''
@@ -301,9 +295,6 @@ class FilePath(object):
     def __repr__(self):
         return "{name:(%s) dirname:(%s) basename:(%s)}" \
             % (self.name, self.dirname, self.basename)
-
-    def __str__(self):
-        return self.__repr__(self)
 
 
 class SchemaInfo(object):
@@ -326,6 +317,3 @@ class SchemaInfo(object):
     def __repr__(self):
         return "{name:(%s) header:(%s) source:(%s) prefix:(%s)}" \
             % (self.name, self.header, self.source, self.prefix)
-
-    def __str__(self):
-        return self.__repr__(self)


### PR DESCRIPTION
fix compilation error with clang++17
    
ocispec/runtime_spec_schema_config_schema.h contains the following code which uses the reserved c++ keyword "class":
    typedef struct {
        char *class;
        int32_t priority;
        yajl_val _residual;
        unsigned int priority_present : 1;
    }
    
Thus the code fails to compile with clang++ 17.
    
Fixes #132 ( https://github.com/containers/libocispec/issues/132 )
