### PR TITLE
Add jansson JSON library

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,9 +42,9 @@ jobs:
 
           run: |
             find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
-            ./autogen.sh --enable-embedded-yajl
-            ./configure --enable-embedded-yajl CFLAGS='-Wall -Wextra -Werror'
-            make -j $(nproc) distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-embedded-yajl"
+            ./autogen.sh --enable-embedded-yajl --enable-embedded-jansson
+            ./configure --enable-embedded-yajl --enable-embedded-jansson CFLAGS='-Wall -Wextra -Werror'
+            make -j $(nproc) distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-embedded-yajl --enable-embedded-jansson" AM_DISTCHECK_DVI_TARGET="" TESTS=""
             # check that the working dir is clean
             git describe --broken --dirty --all | grep -qv dirty
             make clean

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "yajl"]
 	path = yajl
 	url = https://github.com/containers/yajl.git
+[submodule "jansson"]
+	path = jansson
+	url = https://github.com/akheron/jansson

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,11 +1,15 @@
-DIST_SUBDIRS = yajl
-SUBDIRS = yajl
+DIST_SUBDIRS = yajl jansson
+SUBDIRS = yajl jansson
 
 AM_CFLAGS = $(WARN_CFLAGS) -I$(top_srcdir)/src -I$(top_builddir)/src
 
 if HAVE_EMBEDDED_YAJL
 AM_CFLAGS += -I$(top_srcdir)/yajl/src/headers
 endif HAVE_EMBEDDED_YAJL
+
+if HAVE_EMBEDDED_JANSSON
+AM_CFLAGS += -I$(top_srcdir)/jansson/src
+endif HAVE_EMBEDDED_JANSSON
 
 CLEANFILES = $(man_MANS) src/runtime_spec_stamp src/image_spec_stamp src/image_manifest_stamp src/basic-test_stamp
 
@@ -159,6 +163,12 @@ if HAVE_EMBEDDED_YAJL
 TESTS_LDADD += yajl/libyajl.la
 else
 TESTS_LDADD += $(YAJL_LIBS)
+endif
+
+if HAVE_EMBEDDED_JANSSON
+TESTS_LDADD += jansson/src/.libs/libjansson.la
+else
+TESTS_LDADD += $(JANSSON_LIBS)
 endif
 
 libocispec_a_SOURCES =

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ from C, and generate json string from corresponding struct.
 The parser is generated directly from the JSON schema in the source repository.
 
 ## Installation
-Expects [yajl](https://github.com/containers/yajl) to be installed and linkable.
+Expects [yajl](https://github.com/containers/yajl) and [jansson](https://github.com/akheron/jansson) to be installed and linkable.
 ```sh
 $ ./autogen.sh
 $ ./configure

--- a/autogen.sh
+++ b/autogen.sh
@@ -15,6 +15,8 @@ if ! (autoreconf --version >/dev/null 2>&1); then
         exit 1
 fi
 
+(cd ./jansson; autoreconf -i)
+
 mkdir -p m4
 
 autoreconf --force --install --verbose

--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,8 @@ AM_INIT_AUTOMAKE([1.11 -Wno-portability foreign tar-ustar no-dist-gzip dist-xz s
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])
 
-AM_EXTRA_RECURSIVE_TARGETS([yajl])
-AC_CONFIG_SUBDIRS([yajl])
+AM_EXTRA_RECURSIVE_TARGETS([yajl jansson])
+AC_CONFIG_SUBDIRS([yajl jansson])
 
 AC_ARG_ENABLE(embedded-yajl,
 AS_HELP_STRING([--enable-embedded-yajl], [Statically link a modified yajl version]),
@@ -28,6 +28,21 @@ AM_CONDITIONAL([HAVE_EMBEDDED_YAJL], [test x"$embedded_yajl" = xtrue])
 AM_COND_IF([HAVE_EMBEDDED_YAJL], [], [
 AC_SEARCH_LIBS(yajl_tree_get, [yajl], [AC_DEFINE([HAVE_YAJL], 1, [Define if libyajl is available])], [AC_MSG_ERROR([*** libyajl headers not found])])
 PKG_CHECK_MODULES([YAJL], [yajl >= 2.0.0])
+])
+
+AC_ARG_ENABLE(embedded-jansson,
+AS_HELP_STRING([--enable-embedded-jansson], [Statically link a jansson version]),
+[
+case "${enableval}" in
+  yes) embedded_jansson=true ;;
+  no)  embedded_jansson=false ;;
+  *) AC_MSG_ERROR(bad value ${enableval} for --enable-embedded-jansson) ;;
+esac],[embedded_jansson=false])
+
+AM_CONDITIONAL([HAVE_EMBEDDED_JANSSON], [test x"$embedded_jansson" = xtrue])
+AM_COND_IF([HAVE_EMBEDDED_JANSSON], [], [
+AC_SEARCH_LIBS(json_object, [jansson], [AC_DEFINE([HAVE_JANSSON], 1, [Define if libjansson is available])], [AC_MSG_ERROR([*** libjansson headers not found])])
+PKG_CHECK_MODULES([JANSSON], [jansson >= 2.14])
 ])
 
 # Optionally install the library.

--- a/ocispec.pc.in
+++ b/ocispec.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 Description: A library for easily parsing [OCI runtime](https://github.com/opencontainers/runtime-spec) and [OCI image](https://github.com/opencontainers/image-spec) files.
-Requires: yajl
+Requires: yajl jansson
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -locispec
 Cflags: -I${includedir}/ocispec


### PR DESCRIPTION
This is the first step in migrating from yajl to jansson. We now enable to link it in the same way and add it as dependency to the project.

Q: Should we merge this into a dedicated development branch or is it fine to directly target `main`?

Refers to https://github.com/containers/libocispec/issues/138