### PR TITLE
ocispec: Add string-to-object map support and refactor helper classes

### DIFF
--- a/src/ocispec/generate.py
+++ b/src/ocispec/generate.py
@@ -53,7 +53,7 @@ Description: root paths
 Interface: rootpaths
 History: 2019-06-17
 '''
-class MyRoot(object):
+class MyRoot:
     '''
     Description: Store schema information
     Interface: None
@@ -275,7 +275,7 @@ def get_type_pattern_incur(cur, schema_info, src, curfile):
     return typ
 
 
-class GenerateNodeInfo(object):
+class GenerateNodeInfo:
     '''
     Description: Store schema information
     Interface: None

--- a/src/ocispec/generate.py
+++ b/src/ocispec/generate.py
@@ -450,7 +450,11 @@ def gen_obj_typnode(node_info, src, typ, refname):
     subtypobj = None
     required = None
 
-    if 'allOf' in cur:
+    if 'additionalProperties' in cur and isinstance(cur['additionalProperties'], dict):
+        child, src_child = resolve_type(schema_info, name, src, cur['additionalProperties'], curfile)
+        child.fixname = "values"
+        return helpers.SchemaNode(name, 'mapStringObject', [child], None, None, None), src
+    elif 'allOf' in cur:
         children = merge(resolve_list(schema_info, name, src, cur['allOf'], curfile))
     elif 'anyOf' in cur:
         children = resolve_list(schema_info, name, src, cur['anyOf'], curfile)

--- a/src/ocispec/generate.py
+++ b/src/ocispec/generate.py
@@ -550,9 +550,9 @@ def resolve_list(schema_info, name, schema, objs, curfile):
     obj = []
     index = 0
     for i in objs:
-        generated_name = helpers.CombinateName( \
+        generated_name = helpers.HierarchicalName( \
             i['$ref'].split("/")[-1]) if '$ref' in i \
-            else helpers.CombinateName(name.name + str(index))
+            else helpers.HierarchicalName(name.name + str(index))
         node, _ = resolve_type(schema_info, generated_name, schema, i, curfile)
         if node:
             obj.append(node)
@@ -600,8 +600,8 @@ def handle_type_not_in_schema(schema_info, schema, prefix):
     required = None
     if 'definitions' in schema:
         return helpers.SchemaNode( \
-            helpers.CombinateName("definitions"), 'definitions', \
-            parse_properties(schema_info, helpers.CombinateName(""), schema, schema, \
+            helpers.HierarchicalName("definitions"), 'definitions', \
+            parse_properties(schema_info, helpers.HierarchicalName(""), schema, schema, \
                             schema_info.name.name), None, None, None, None)
     else:
         if len(schema) > 1:
@@ -611,14 +611,14 @@ def handle_type_not_in_schema(schema_info, schema, prefix):
         for value in schema:
             if 'required' in schema[value]:
                 required = schema[value]['required']
-            childrens = parse_properties(schema_info, helpers.CombinateName(""), \
+            childrens = parse_properties(schema_info, helpers.HierarchicalName(""), \
                                         schema[value], schema[value], \
                                         schema_info.name.name)
-            value_node = helpers.SchemaNode(helpers.CombinateName(prefix), \
+            value_node = helpers.SchemaNode(helpers.HierarchicalName(prefix), \
                                        'object', childrens, None, None, \
                                        None, required)
             value_nodes.append(value_node)
-        return helpers.SchemaNode(helpers.CombinateName("definitions"), \
+        return helpers.SchemaNode(helpers.HierarchicalName("definitions"), \
                              'definitions', value_nodes, None, None, \
                             None, None)
 
@@ -637,19 +637,19 @@ def parse_schema(schema_info, schema, prefix):
         if 'required' in schema:
             required = schema['required']
         return helpers.SchemaNode(
-            helpers.CombinateName(prefix), 'object',
+            helpers.HierarchicalName(prefix), 'object',
             parse_properties(schema_info, \
-                            helpers.CombinateName(""), \
+                            helpers.HierarchicalName(""), \
                             schema, schema, schema_info.name.name), \
             None, None, None, required)
     elif 'array' in schema['type']:
-        item_type, _ = resolve_type(schema_info, helpers.CombinateName(""), \
+        item_type, _ = resolve_type(schema_info, helpers.HierarchicalName(""), \
                                     schema['items'], schema['items'], schema_info.name.name)
         if item_type.typ == 'array' and not helpers.valid_basic_map_name(item_type.subtyp):
             item_type.doublearray = True
             return item_type
         else:
-            return helpers.SchemaNode(helpers.CombinateName(prefix), 'array', None, item_type.typ, \
+            return helpers.SchemaNode(helpers.HierarchicalName(prefix), 'array', None, item_type.typ, \
                             item_type.children, None, item_type.required)
 
     else:
@@ -673,7 +673,7 @@ def expand(tree, structs, visited):
             expand(i, structs, visited=visited)
 
     if tree.typ == 'array' and helpers.valid_basic_map_name(tree.subtyp):
-        name = helpers.CombinateName(tree.name + "_element")
+        name = helpers.HierarchicalName(tree.name + "_element")
         node = helpers.SchemaNode(name, tree.subtyp, None)
         expand(node, structs, visited)
 

--- a/src/ocispec/generate.py
+++ b/src/ocispec/generate.py
@@ -321,7 +321,7 @@ def gen_all_arr_typnode(node_info, src, typ, refname):
     children = merge(resolve_list(schema_info, name, src, cur["items"]['allOf'], curfile))
     subtyp = children[0].typ
     subtypobj = children
-    return helpers.Unite(name,
+    return helpers.SchemaNode(name,
                         typ,
                         children,
                         subtyp=subtyp,
@@ -348,7 +348,7 @@ def gen_any_arr_typnode(node_info, src, typ, refname):
     children = anychildren[0].children
     subtypobj = children
     refname = anychildren[0].subtypname
-    return helpers.Unite(name,
+    return helpers.SchemaNode(name,
                         typ,
                         children,
                         subtyp=subtyp,
@@ -375,7 +375,7 @@ def gen_ref_arr_typnode(node_info, src, typ, refname):
         refname = make_ref_name(subrefname, curfile)
     else:
         refname = item_type.subtypname
-    return helpers.Unite(name,
+    return helpers.SchemaNode(name,
                         typ,
                         None,
                         subtyp=item_type.typ,
@@ -398,7 +398,7 @@ def gen_type_arr_typnode(node_info, src, typ, refname):
     item_type, src = resolve_type(schema_info, name, src, cur["items"], curfile)
 
     if typ == 'array' and typ == item_type.typ and not helpers.valid_basic_map_name(item_type.subtyp):
-        return helpers.Unite(name,
+        return helpers.SchemaNode(name,
                         typ,
                         None,
                         subtyp=item_type.subtyp,
@@ -406,7 +406,7 @@ def gen_type_arr_typnode(node_info, src, typ, refname):
                         subtypname=item_type.subtypname,
                         required=item_type.required, doublearray=True), src
     else:
-        return helpers.Unite(name,
+        return helpers.SchemaNode(name,
                         typ,
                         None,
                         subtyp=item_type.typ,
@@ -466,7 +466,7 @@ def gen_obj_typnode(node_info, src, typ, refname):
             if 'properties' in cur else None
     if 'required' in cur:
         required = cur['required']
-    return helpers.Unite(name,\
+    return helpers.SchemaNode(name,\
             typ,\
             children,\
             subtyp=subtyp,\
@@ -532,7 +532,7 @@ def resolve_type(schema_info, name, src, cur, curfile):
             raise RuntimeError("Invalid schema type: %s" % typ)
         children = None
 
-    return helpers.Unite(name,
+    return helpers.SchemaNode(name,
                         typ,
                         children,
                         subtyp=subtyp,
@@ -599,7 +599,7 @@ def handle_type_not_in_schema(schema_info, schema, prefix):
     """
     required = None
     if 'definitions' in schema:
-        return helpers.Unite( \
+        return helpers.SchemaNode( \
             helpers.CombinateName("definitions"), 'definitions', \
             parse_properties(schema_info, helpers.CombinateName(""), schema, schema, \
                             schema_info.name.name), None, None, None, None)
@@ -614,11 +614,11 @@ def handle_type_not_in_schema(schema_info, schema, prefix):
             childrens = parse_properties(schema_info, helpers.CombinateName(""), \
                                         schema[value], schema[value], \
                                         schema_info.name.name)
-            value_node = helpers.Unite(helpers.CombinateName(prefix), \
+            value_node = helpers.SchemaNode(helpers.CombinateName(prefix), \
                                        'object', childrens, None, None, \
                                        None, required)
             value_nodes.append(value_node)
-        return helpers.Unite(helpers.CombinateName("definitions"), \
+        return helpers.SchemaNode(helpers.CombinateName("definitions"), \
                              'definitions', value_nodes, None, None, \
                             None, None)
 
@@ -636,7 +636,7 @@ def parse_schema(schema_info, schema, prefix):
     if 'object' in schema['type']:
         if 'required' in schema:
             required = schema['required']
-        return helpers.Unite(
+        return helpers.SchemaNode(
             helpers.CombinateName(prefix), 'object',
             parse_properties(schema_info, \
                             helpers.CombinateName(""), \
@@ -649,7 +649,7 @@ def parse_schema(schema_info, schema, prefix):
             item_type.doublearray = True
             return item_type
         else:
-            return helpers.Unite(helpers.CombinateName(prefix), 'array', None, item_type.typ, \
+            return helpers.SchemaNode(helpers.CombinateName(prefix), 'array', None, item_type.typ, \
                             item_type.children, None, item_type.required)
 
     else:
@@ -674,7 +674,7 @@ def expand(tree, structs, visited):
 
     if tree.typ == 'array' and helpers.valid_basic_map_name(tree.subtyp):
         name = helpers.CombinateName(tree.name + "_element")
-        node = helpers.Unite(name, tree.subtyp, None)
+        node = helpers.SchemaNode(name, tree.subtyp, None)
         expand(node, structs, visited)
 
     id_ = "%s:%s" % (tree.name, tree.typ)

--- a/src/ocispec/headers.py
+++ b/src/ocispec/headers.py
@@ -75,7 +75,7 @@ def append_header_map_str_obj(obj, header, prefix):
     if helpers.valid_basic_map_name(child.typ):
         c_typ = helpers.get_prefixed_pointer("", child.typ, "")
     elif child.subtypname:
-        c_typ = child.subtypname
+        c_typ = child.subtypname +  " *"
     else:
         c_typ = helpers.get_prefixed_pointer(child.name, child.typ, prefix)
     header.append(f"    {c_typ}{' ' if '*' not in c_typ else ''}*{child.fixname};\n")

--- a/src/ocispec/headers.py
+++ b/src/ocispec/headers.py
@@ -45,7 +45,7 @@ def append_header_arr(obj, header, prefix):
             if i.subtypobj is not None:
                 c_typ = helpers.get_name_substr(i.name, prefix)
 
-            if not helpers.judge_complex(i.subtyp):
+            if not helpers.is_compound_type(i.subtyp):
                 header.append(f"    {c_typ}{' ' if '*' not in c_typ else ''}*{i.fixname};\n")
             else:
                 header.append(f"    {c_typ} **{i.fixname};\n")
@@ -105,7 +105,7 @@ def append_header_child_arr(child, header, prefix):
 
     if helpers.valid_basic_map_name(child.subtyp):
         header.append(f"    {helpers.make_basic_map_name(child.subtyp)} **{child.fixname};\n")
-    elif not helpers.judge_complex(child.subtyp):
+    elif not helpers.is_compound_type(child.subtyp):
         header.append(f"    {c_typ}{' ' if '*' not in c_typ else ''}*{dflag}{child.fixname};\n")
     else:
         header.append(f"    {c_typ}{' ' if '*' not in c_typ else ''}**{dflag}{child.fixname};\n")
@@ -138,7 +138,7 @@ def append_type_c_header(obj, header, prefix):
     Interface: None
     History: 2019-06-17
     '''
-    if not helpers.judge_complex(obj.typ):
+    if not helpers.is_compound_type(obj.typ):
         return
 
     if obj.typ == 'array':

--- a/src/ocispec/helpers.py
+++ b/src/ocispec/helpers.py
@@ -184,7 +184,7 @@ def get_prefixed_pointer(name, typ, prefix):
     return '%s *' % make_basic_map_name(typ) if valid_basic_map_name(typ) \
         else "%s *" % get_prefixed_name(name, prefix)
 
-def judge_complex(typ):
+def is_compound_type(typ):
     '''
     Description: Check compound object
     Interface: None

--- a/src/ocispec/helpers.py
+++ b/src/ocispec/helpers.py
@@ -178,7 +178,7 @@ def get_prefixed_pointer(name, typ, prefix):
     Interface: None
     History: 2019-06-17
     '''
-    if typ != 'object' and typ != 'mapStringObject' and \
+    if typ != 'array' and typ != 'object' and typ != 'mapStringObject' and \
             not valid_basic_map_name(typ):
         return ""
     return '%s *' % make_basic_map_name(typ) if valid_basic_map_name(typ) \

--- a/src/ocispec/helpers.py
+++ b/src/ocispec/helpers.py
@@ -235,9 +235,9 @@ def obtain_pointer(name, typ, prefix):
     return "char *" if typ == "string" else \
         ("%s *" % typ if typ == "ArrayOfStrings" else "")
 
-class CombinateName(object):
+class HierarchicalName(object):
     '''
-    Description: Store CombinateName information
+    Description: Store HierarchicalName information
     Interface: None
     History: 2019-06-17
     '''
@@ -256,7 +256,7 @@ class CombinateName(object):
         History: 2019-06-17
         '''
         prefix_name = self.name + '_' if self.name != "" else ""
-        return CombinateName(prefix_name + leaf, leaf)
+        return HierarchicalName(prefix_name + leaf, leaf)
 
 
 class SchemaNode(object):

--- a/src/ocispec/helpers.py
+++ b/src/ocispec/helpers.py
@@ -259,9 +259,9 @@ class CombinateName(object):
         return CombinateName(prefix_name + leaf, leaf)
 
 
-class Unite(object):
+class SchemaNode(object):
     '''
-    Description: Store Unite information
+    Description: Store SchemaNode information
     Interface: None
     History: 2019-06-17
     '''

--- a/src/ocispec/helpers.py
+++ b/src/ocispec/helpers.py
@@ -235,7 +235,7 @@ def obtain_pointer(name, typ, prefix):
     return "char *" if typ == "string" else \
         ("%s *" % typ if typ == "ArrayOfStrings" else "")
 
-class HierarchicalName(object):
+class HierarchicalName:
     '''
     Description: Store HierarchicalName information
     Interface: None
@@ -259,7 +259,7 @@ class HierarchicalName(object):
         return HierarchicalName(prefix_name + leaf, leaf)
 
 
-class SchemaNode(object):
+class SchemaNode:
     '''
     Description: Store SchemaNode information
     Interface: None
@@ -287,7 +287,7 @@ class SchemaNode(object):
         return "name:(%s) type:(%s)" % (self.name, self.typ)
 
 
-class FilePath(object):
+class FilePath:
     '''
     Description: Store filepath information
     Interface: None
@@ -303,7 +303,7 @@ class FilePath(object):
             % (self.name, self.dirname, self.basename)
 
 
-class SchemaInfo(object):
+class SchemaInfo:
     '''
     Description: Store schema information
     Interface: None

--- a/src/ocispec/sources.py
+++ b/src/ocispec/sources.py
@@ -355,7 +355,7 @@ def parse_json_to_c(obj, c_file, prefix):
     Interface: None
     History: 2019-06-17
     """
-    if not helpers.judge_complex(obj.typ):
+    if not helpers.is_compound_type(obj.typ):
         return
     if obj.typ == 'object' or obj.typ == 'mapStringObject':
         if obj.subtypname:
@@ -653,7 +653,7 @@ def get_c_json(obj, c_file, prefix):
     Interface: None
     History: 2019-06-17
     """
-    if not helpers.judge_complex(obj.typ) or obj.subtypname:
+    if not helpers.is_compound_type(obj.typ) or obj.subtypname:
         return
     if obj.typ == 'object' or obj.typ == 'mapStringObject':
         typename = helpers.get_prefixed_name(obj.name, prefix)
@@ -839,7 +839,7 @@ def make_clone(obj, c_file, prefix):
     History: 2024-09-03
     """
 
-    if not helpers.judge_complex(obj.typ) or obj.subtypname:
+    if not helpers.is_compound_type(obj.typ) or obj.subtypname:
         return
     typename = helpers.get_prefixed_name(obj.name, prefix)
     case = obj.typ
@@ -1041,7 +1041,7 @@ def make_c_array_free (i, c_file, prefix):
         c_file.append("      }\n")
     elif i.subtyp == 'string':
         c_file_str(c_file, i)
-    elif not helpers.judge_complex(i.subtyp):
+    elif not helpers.is_compound_type(i.subtyp):
         c_file.append("   {\n")
         if i.doublearray:
             c_file.append("            size_t i;\n")
@@ -1103,7 +1103,7 @@ def make_c_free (obj, c_file, prefix):
     Interface: None
     History: 2019-06-17
     """
-    if not helpers.judge_complex(obj.typ) or obj.subtypname:
+    if not helpers.is_compound_type(obj.typ) or obj.subtypname:
         return
     typename = helpers.get_prefixed_name(obj.name, prefix)
     case = obj.typ
@@ -1382,7 +1382,7 @@ def get_c_epilog_for_array_make_free(c_file, prefix, typ, obj):
         else:
             c_file.append("        free (ptr->items[i]);\n")
             c_file.append("        ptr->items[i] = NULL;\n")
-    elif not helpers.judge_complex(obj.subtyp):
+    elif not helpers.is_compound_type(obj.subtyp):
         if obj.doublearray:
             c_file.append("        free (ptr->items[i]);\n")
             c_file.append("        ptr->items[i] = NULL;\n")

--- a/src/ocispec/sources.py
+++ b/src/ocispec/sources.py
@@ -843,7 +843,8 @@ def make_clone(obj, c_file, prefix):
         return
     typename = helpers.get_prefixed_name(obj.name, prefix)
     case = obj.typ
-    result = {'mapStringObject': lambda x: [], 'object': lambda x: x.children,
+    result = {'mapStringObject': lambda x: [],
+              'object': lambda x: x.children,
               'array': lambda x: x.subtypobj}[case](obj)
     objs = result
     if obj.typ == 'array':
@@ -861,7 +862,7 @@ def make_clone(obj, c_file, prefix):
     c_file.append("    if (ret == NULL)\n")
     c_file.append("      return NULL;\n")
 
-    nodes = obj.children if obj.typ == 'object' else obj.subtypobj
+    nodes = obj.children if obj.subtypobj is None else obj.subtypobj
     for i in nodes or []:
         if helpers.judge_data_type(i.typ) or i.typ == 'boolean':
             c_file.append(f"    ret->{i.fixname} = src->{i.fixname};\n")
@@ -870,9 +871,19 @@ def make_clone(obj, c_file, prefix):
             node_name = i.subtypname or helpers.get_prefixed_name(i.name, prefix)
             c_file.append(f"    if (src->{i.fixname})\n")
             c_file.append(f"      {{\n")
-            c_file.append(f"        ret->{i.fixname} = clone_{node_name} (src->{i.fixname});\n")
-            c_file.append(f"        if (ret->{i.fixname} == NULL)\n")
-            c_file.append(f"          return NULL;\n")
+            if obj.typ != 'mapStringObject':
+                c_file.append(f"        ret->{i.fixname} = clone_{node_name} (src->{i.fixname});\n")
+                c_file.append(f"        if (ret->{i.fixname} == NULL)\n")
+                c_file.append(f"          return NULL;\n")
+            else:
+                c_file.append(f"        size_t i;\n")
+                c_file.append(f"        ret->{i.fixname} = calloc (src->len + 1, sizeof (*ret->{i.fixname}));\n")
+                c_file.append(f"        for (i = 0; i < src->len; i++)\n")
+                c_file.append("          {\n")
+                c_file.append(f"             ret->{i.fixname}[i] = clone_{node_name} (src->{i.fixname}[i]);\n")
+                c_file.append(f"             if (ret->{i.fixname}[i] == NULL);\n")
+                c_file.append(f"               return NULL;\n")
+                c_file.append("          }\n")
             c_file.append(f"      }}\n")
         elif i.typ == 'string':
             c_file.append(f"    if (src->{i.fixname})\n")
@@ -947,9 +958,16 @@ def make_clone(obj, c_file, prefix):
             c_file.append(f"    if (ret->{i.fixname} == NULL)\n")
             c_file.append(f"        return NULL;\n")
         elif i.typ == 'mapStringObject':
+            if i.subtypname is not None:
+                subtypname = i.subtypname
+                maybe_element = "_element"
+            else:
+                subtypname = i.children[0].subtypname
+                maybe_element = ""
+
             c_file.append(f"    if (src->{i.fixname})\n")
             c_file.append(f"      {{\n")
-            c_file.append(f"        ret->{i.fixname} = calloc (1, sizeof ({i.subtypname}));\n")
+            c_file.append(f"        ret->{i.fixname} = calloc (1, sizeof (*ret->{i.fixname}));\n")
             c_file.append(f"        if (ret->{i.fixname} == NULL)\n")
             c_file.append(f"            return NULL;\n")
             c_file.append(f"        ret->{i.fixname}->len = src->{i.fixname}->len;\n")
@@ -964,7 +982,7 @@ def make_clone(obj, c_file, prefix):
             c_file.append(f"            ret->{i.fixname}->keys[i] = strdup (src->{i.fixname}->keys[i]);\n")
             c_file.append(f"            if (ret->{i.fixname}->keys[i] == NULL)\n")
             c_file.append(f"              return NULL;\n")
-            c_file.append(f"            ret->{i.fixname}->values[i] = clone_{i.subtypname}_element (src->{i.fixname}->values[i]);\n")
+            c_file.append(f"            ret->{i.fixname}->values[i] = clone_{subtypname}{maybe_element} (src->{i.fixname}->values[i]);\n")
             c_file.append(f"            if (ret->{i.fixname}->values[i] == NULL)\n")
             c_file.append(f"              return NULL;\n")
             c_file.append(f"          }}\n")
@@ -1073,7 +1091,7 @@ def make_c_array_free (i, c_file, prefix):
     c_typ = helpers.obtain_pointer(i.name, i.subtypobj, prefix)
     if c_typ == "":
         return True
-    if i.subobj is not None:
+    if i.subtypname is not None:
         c_typ = c_typ + "_element"
     c_file.append(f"    free_{c_typ} (ptr->{i.fixname});\n")
     c_file.append(f"    ptr->{i.fixname} = NULL;\n")
@@ -1089,7 +1107,8 @@ def make_c_free (obj, c_file, prefix):
         return
     typename = helpers.get_prefixed_name(obj.name, prefix)
     case = obj.typ
-    result = {'mapStringObject': lambda x: [], 'object': lambda x: x.children,
+    result = {'mapStringObject': lambda x: [],
+              'object': lambda x: x.children,
               'array': lambda x: x.subtypobj}[case](obj)
     objs = result
     if obj.typ == 'array':


### PR DESCRIPTION
introduce support for `string->object` maps in the code generation.

This is needed to handle net_devices in the OCI runtime specs: https://github.com/containers/crun/issues/1712