### PR TITLE
sources.py: fix unconditional return in map value clone

### DIFF
--- a/src/ocispec/sources.py
+++ b/src/ocispec/sources.py
@@ -881,7 +881,7 @@ def make_clone(obj, c_file, prefix):
                 c_file.append(f"        for (i = 0; i < src->len; i++)\n")
                 c_file.append("          {\n")
                 c_file.append(f"             ret->{i.fixname}[i] = clone_{node_name} (src->{i.fixname}[i]);\n")
-                c_file.append(f"             if (ret->{i.fixname}[i] == NULL);\n")
+                c_file.append(f"             if (ret->{i.fixname}[i] == NULL)\n")
                 c_file.append(f"               return NULL;\n")
                 c_file.append("          }\n")
             c_file.append(f"      }}\n")


### PR DESCRIPTION
In the generated C code for cloning the object values of a mapStringObject, an 'if' statement checking for cloning failure was followed by an erroneous semicolon.

This caused the 'if' to have an empty body, leading to the subsequent 'return NULL;' being executed unconditionally in the first iteration of the value-cloning loop if the map was not empty. Consequently, cloning a mapStringObject with one or more elements would always fail prematurely when this specific path for object-values was taken.

Removing the semicolon makes the 'return NULL;' conditional upon actual cloning failure, as intended.