### PR TITLE
json_common: disable slash escaping

### DIFF
--- a/src/ocispec/json_common.c
+++ b/src/ocispec/json_common.c
@@ -216,7 +216,7 @@ json_gen_status
 json_gen_get_buf (json_gen_ctx *g, const char **buf, size_t *len)
 {
   const char *str;
-  int flags = JSON_C_TO_STRING_SPACED;
+  int flags = JSON_C_TO_STRING_SPACED | JSON_C_TO_STRING_NOSLASHESCAPE;
 
   if (g->buf != NULL)
     {
@@ -225,7 +225,7 @@ json_gen_get_buf (json_gen_ctx *g, const char **buf, size_t *len)
     }
 
   if (g->beautify)
-    flags = JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED;
+    flags |= JSON_C_TO_STRING_PRETTY;
 
   if (g->root == NULL)
     return json_gen_in_error_state;


### PR DESCRIPTION
slash escaping in json is optional, and was disabled in yajl.

This restores the previous behavior for compatibility with fragile scripts parsing the output

Link: https://github.com/containers/crun/issues/2115

-------------------

Thanks @giuseppe for checking

I'll open a PR disabling prettify for hook and bumping the submodule in crun after this is merged