### PR TITLE
fuzzing: fix honggfuzz build by linking libzstd

### DIFF
--- a/tests/fuzzing/Dockerfile
+++ b/tests/fuzzing/Dockerfile
@@ -1,9 +1,10 @@
 FROM quay.io/fedora/fedora:latest
 
 RUN dnf install -y python3 automake autoconf libtool make git pkg-config clang \
-    glibc-static libunwind-devel binutils-devel xz-devel libatomic json-c-devel
+    glibc-static libunwind-devel binutils-devel xz-devel libatomic json-c-devel \
+    libzstd-devel
 
-RUN git clone --depth 1 https://github.com/google/honggfuzz.git && cd honggfuzz && make -j $(nproc) && make install PREFIX=/usr
+RUN git clone --depth 1 https://github.com/google/honggfuzz.git && cd honggfuzz && sed -i 's/LDFLAGS\s*+=/LDFLAGS += -lzstd/' Makefile && make -j $(nproc) && make install PREFIX=/usr
 
 COPY run-tests.sh /usr/local/bin
 


### PR DESCRIPTION
libbfd now requires libzstd, causing undefined references to ZSTD_isError, ZSTD_compress and ZSTD_decompress when building honggfuzz.  Install libzstd-devel and patch the honggfuzz Makefile to add -lzstd to LDFLAGS.